### PR TITLE
(feat) Add support for passing headers & cookies

### DIFF
--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -94,15 +94,12 @@ if (!cliSetWait && typeof config.wait === 'number') {
 // Resolve env vars in auth config
 if (config.resolveEnvVars && config.auth) {
   if (config.auth.cookies) {
-    console.log(`  \x1b[2mLoading ${config.auth.cookies.length} cookie(s) from config\x1b[0m`)
     config.auth.cookies = config.auth.cookies.map(c => ({
       ...c,
       value: replaceEnvStrings(c.value)
     }))
   }
   if (config.auth.headers) {
-    const headerCount = Object.keys(config.auth.headers).length
-    console.log(`  \x1b[2mLoading ${headerCount} header(s) from config\x1b[0m`)
     for (const [key, val] of Object.entries(config.auth.headers)) {
       config.auth.headers[key] = replaceEnvStrings(val)
     }
@@ -303,8 +300,8 @@ if (config.auth) {
     await page.context().addCookies(config.auth.cookies)
   }
   if (config.auth.headers) {
-    const headerCount = Object.keys(config.auth.headers).length
-    console.log(`  \x1b[2mApplying ${headerCount} header(s) to browser session\x1b[0m`)
+    const count = Object.keys(config.auth.headers).length
+    console.log(`  \x1b[2mApplying ${count} header(s) to browser session\x1b[0m`)
     await page.setExtraHTTPHeaders(config.auth.headers)
   }
 }


### PR DESCRIPTION
Closes #4 

### Why?
Currently, if your app has auth-protected routes, there is no way to generate skeletons for components on those routes. 

By passing auth context as cookies & headers, you can access these routes.

### Potential Future Changes
As suggested in the issue comments, it may be useful to be able to define multiple login sessions and perform a crawl using each session.

### New Config Keys
```json
{
  "resolveEnvVars": true,
  "auth": {
    "cookies": [{ "name": "session", "value": "env[SESSION_TOKEN]" }],
    "headers": { "Authorization": "Bearer env[TOKEN]" }
  }
}
```
*Example in help text*

###  Summary of Changes
**packages/boneyard/bin/cli.js**

1. Extracted gotoPage function (lines 28-38, 341-349)
   - Removed duplicated page.goto logic from capturePage and discoverLinks
2. Added replaceEnvStrings function (lines 118-124)
   - Replaces env[VAR_NAME] syntax with actual environment variable values
   - Uses regex + callback pattern correctly
3. Added resolveEnv function (lines 130-156)
   - Extracts key from env[KEY] syntax
   - Looks up in process.env, exits with error if not found
4. Added auth config resolution (lines 94-110)
   - Processes config.auth.cookies — resolves env vars in cookie values
   - Processes config.auth.headers — resolves env vars in header values
   - Added loglines: "Loading X cookie(s) from config" / "Loading X header(s) from config"
5. Added auth application to browser (lines 302-310)
   - Applies cookies via page.context().addCookies()
   - Applies headers via page.setExtraHTTPHeaders()
   - Added loglines: "Applying X cookie(s) to browser session" / "Applying X header(s) to browser session"
6. Updated help text (lines 678-690)
   - Added Authentication section with example config
   - Documents resolveEnvVars, auth.cookies, auth.headers, env[VAR] syntax
   - Notes env var resolution only works for auth config