### PR TITLE
Add "import" condition to ./angular package export (#42)

### DIFF
--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -42,6 +42,7 @@
     },
     "./angular": {
       "types": "./dist/angular.d.ts",
+      "import": "./dist/angular.ts",
       "default": "./dist/angular.ts"
     },
     "./vite": {


### PR DESCRIPTION
The ./angular export only had "default" but not "import", causing ESM resolution failures in Angular projects. Add the "import" condition for consistency with the ./vue export.

Fixes #42