### PR TITLE
chore: set VS Code package manager to pnpm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "npm.packageManager": "pnpm"
+}


### PR DESCRIPTION
Adds `.vscode/settings.json` with `npm.packageManager` set to `pnpm`. This prevents VS Code from running `npm run build` and generating a `package-lock.json` when setting up the workspace, ensuring pnpm is used consistently.