### PR TITLE
fix: update homepage to project site

### DIFF
--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -113,7 +113,7 @@
     "type": "git",
     "url": "https://github.com/0xGF/boneyard"
   },
-  "homepage": "https://github.com/0xGF/boneyard",
+  "homepage": "https://boneyard.vercel.app",
   "optionalDependencies": {
     "@chenglou/pretext": "^0.0.3"
   },


### PR DESCRIPTION
Changes the `homepage` field in `package.json` from the GitHub repo URL to `https://boneyard.vercel.app`, the actual project site.