### PR TITLE
chore: bump @chenglou/pretext from ^0.0.3 to ^0.0.5

### DIFF
--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -115,7 +115,7 @@
   },
   "homepage": "https://github.com/0xGF/boneyard",
   "optionalDependencies": {
-    "@chenglou/pretext": "^0.0.3"
+    "@chenglou/pretext": "^0.0.5"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
       '@chenglou/pretext':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
 
 packages:
 
@@ -834,8 +834,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@chenglou/pretext@0.0.3':
-    resolution: {integrity: sha512-RQmqMqUAPRCyv4R3LlRi/ao6KbNWYclqLA+V1HS7sWgyUUbjn3JmmlfXZSY/BjM4rbmIaMSyIVisYocYGYftiQ==}
+  '@chenglou/pretext@0.0.5':
+    resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -5248,7 +5248,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@chenglou/pretext@0.0.3':
+  '@chenglou/pretext@0.0.5':
     optional: true
 
   '@codemirror/autocomplete@6.20.1':
@@ -7110,7 +7110,7 @@ snapshots:
       playwright: 1.59.0
     optionalDependencies:
       '@angular/core': 21.2.7(rxjs@7.8.2)
-      '@chenglou/pretext': 0.0.3
+      '@chenglou/pretext': 0.0.5
       react: 19.2.4
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4)
       svelte: 5.55.1


### PR DESCRIPTION
Bumps `@chenglou/pretext` to the latest version. Changes in 0.0.4–0.0.5 are performance improvements (linear scans for Arabic/CJK merges, deferred punctuation materialization) and bug fixes — no API breaking changes.

All tests (119/119) and layout benchmarks pass.