### PR TITLE
Add native Preact integration without preact/compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Pixel-perfect skeleton loading screens, extracted from your real UI. No manual measurement, no hand-tuned placeholders.
 
-Works with **React**, **Vue**, **Svelte 5**, **Angular**, and **React Native**.
+Works with **React**, **Preact**, **Vue**, **Svelte 5**, **Angular**, and **React Native**.
 
 ## Quick start
 
@@ -57,6 +57,21 @@ const loading = ref(true)
 <Skeleton name="card" {loading}>
   <Card />
 </Skeleton>
+```
+
+### Preact
+
+```tsx
+import { Skeleton } from 'boneyard-js/preact'
+
+function BlogPage() {
+  const { data, isLoading } = useFetch('/api/post')
+  return (
+    <Skeleton name="blog-card" loading={isLoading}>
+      {data && <BlogCard data={data} />}
+    </Skeleton>
+  )
+}
 ```
 
 ### Angular
@@ -110,7 +125,7 @@ import './bones/registry'
 
 ### Vite plugin
 
-For Vite-based projects (Vue, Svelte, React with Vite), use the plugin instead of the CLI — no second terminal needed:
+For Vite-based projects (React, Preact, Vue, Svelte), use the plugin instead of the CLI — no second terminal needed:
 
 ```ts
 // vite.config.ts
@@ -182,6 +197,7 @@ Save as `boneyard.config.json`. Per-component props override config values.
 |--------|-----|
 | `boneyard-js` | `snapshotBones`, `renderBones`, `computeLayout` |
 | `boneyard-js/react` | React `<Skeleton>` |
+| `boneyard-js/preact` | Preact `<Skeleton>` (no compat needed) |
 | `boneyard-js/vue` | Vue `<Skeleton>` |
 | `boneyard-js/svelte` | Svelte `<Skeleton>` |
 | `boneyard-js/angular` | Angular `<boneyard-skeleton>` |

--- a/apps/docs/src/app/agent/llms.txt/route.ts
+++ b/apps/docs/src/app/agent/llms.txt/route.ts
@@ -231,6 +231,24 @@ Generate bones: \`npx boneyard-js build --native --out ./bones\`, then open your
 
 Auth is a non-issue — the app is already running with the user logged in.
 
+## Preact
+
+\`\`\`tsx
+import { Skeleton } from 'boneyard-js/preact'
+import './bones/registry'
+
+function App() {
+  const [loading, setLoading] = useState(true)
+  return (
+    <Skeleton name="card" loading={loading}>
+      <Card />
+    </Skeleton>
+  )
+}
+\`\`\`
+
+Native Preact integration — uses \`preact/hooks\` directly, no \`preact/compat\` needed. Same API as React. Same CLI: \`npx boneyard-js build\`. Works with the Vite plugin.
+
 ## Svelte
 
 \`\`\`svelte
@@ -259,6 +277,7 @@ Uses Svelte 5 snippets for \`fallback\` and \`fixture\`. Same CLI: \`npx boneyar
 
 - \`boneyard-js\` — snapshotBones, renderBones, fromElement
 - \`boneyard-js/react\` — Skeleton, registerBones, configureBoneyard
+- \`boneyard-js/preact\` — Skeleton, registerBones, configureBoneyard (native Preact, no compat needed)
 - \`boneyard-js/native\` — Skeleton, registerBones, configureBoneyard (React Native)
 - \`boneyard-js/svelte\` — Skeleton component, registerBones
 - \`boneyard-js/vue\` — Skeleton component, registerBones, configureBoneyard

--- a/apps/docs/src/app/agent/page.tsx
+++ b/apps/docs/src/app/agent/page.tsx
@@ -207,6 +207,24 @@ Generate bones: \`npx boneyard-js build --native --out ./bones\`, then open your
 
 After generating, add \`import './bones/registry'\` and reload the app.
 
+## Preact
+
+\`\`\`tsx
+import { Skeleton } from 'boneyard-js/preact'
+import './bones/registry'
+
+function App() {
+  const [loading, setLoading] = useState(true)
+  return (
+    <Skeleton name="card" loading={loading}>
+      <Card />
+    </Skeleton>
+  )
+}
+\`\`\`
+
+Native Preact integration — uses \`preact/hooks\` directly, no \`preact/compat\` needed. Same API as React. Same CLI: \`npx boneyard-js build\`. Works with the Vite plugin.
+
 ## Svelte
 
 \`\`\`svelte
@@ -260,6 +278,7 @@ Runtime defaults (\`color\`, \`darkColor\`, \`animate\`) are automatically inclu
 
 - \`boneyard-js\` — snapshotBones, renderBones, fromElement
 - \`boneyard-js/react\` — Skeleton, registerBones, configureBoneyard
+- \`boneyard-js/preact\` — Skeleton, registerBones, configureBoneyard (native Preact, no compat needed)
 - \`boneyard-js/native\` — Skeleton, registerBones, configureBoneyard (React Native)
 - \`boneyard-js/svelte\` — Skeleton component, registerBones
 - \`boneyard-js/vue\` — Skeleton component, registerBones, configureBoneyard

--- a/apps/docs/src/app/preact/page.tsx
+++ b/apps/docs/src/app/preact/page.tsx
@@ -1,0 +1,284 @@
+import { CodeBlock } from "@/components/ui/code-block";
+import { TableOfContents } from "@/components/toc";
+
+const tocItems = [
+  { id: "quick-start", label: "Quick start" },
+  { id: "props", label: "Props" },
+  { id: "vite-plugin", label: "Vite plugin" },
+  { id: "dark-mode", label: "Dark mode" },
+  { id: "animations", label: "Animations" },
+  { id: "global-defaults", label: "Global defaults" },
+  { id: "config-file", label: "Config file" },
+];
+
+export default function PreactPage() {
+  return (
+    <div className="flex gap-10 w-full min-w-0">
+    <div className="w-full max-w-[720px] px-6 pt-14 pb-12 space-y-12">
+      <div>
+        <h1 className="text-[28px] font-bold tracking-tight mb-2">Preact</h1>
+        <p className="text-[15px] text-[#78716c] leading-relaxed">
+          Native Preact integration — uses <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">preact/hooks</code> directly, no <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">preact/compat</code> needed. Same API as React, smaller bundle.
+        </p>
+      </div>
+
+      {/* Quick start */}
+      <section>
+        <div className="section-divider" id="quick-start">
+          <span>Quick start</span>
+        </div>
+        <div className="mt-4 space-y-4">
+          <div>
+            <p className="text-[13px] font-medium text-stone-500 mb-2">1. Install</p>
+            <CodeBlock language="bash" code="npm install boneyard-js" />
+          </div>
+          <div>
+            <p className="text-[13px] font-medium text-stone-500 mb-2">2. Add the component</p>
+            <CodeBlock filename="app.tsx" language="tsx" code={`<span class="text-[#c084fc]">import</span> { Skeleton } <span class="text-[#c084fc]">from</span> <span class="text-[#86efac]">'boneyard-js/preact'</span>
+<span class="text-[#c084fc]">import</span> <span class="text-[#86efac]">'./bones/registry'</span>
+
+<span class="text-[#c084fc]">function</span> <span class="text-[#fde68a]">BlogPage</span>() {
+  <span class="text-[#c084fc]">const</span> { data, isLoading } = <span class="text-[#fde68a]">useFetch</span>(<span class="text-[#86efac]">'/api/post'</span>)
+  <span class="text-[#c084fc]">return</span> (
+    &lt;<span class="text-[#fde68a]">Skeleton</span> <span class="text-[#93c5fd]">name</span>=<span class="text-[#86efac]">"blog-card"</span> <span class="text-[#93c5fd]">loading</span>={isLoading}&gt;
+      {data && &lt;<span class="text-[#fde68a]">BlogCard</span> <span class="text-[#93c5fd]">data</span>={data} /&gt;}
+    &lt;/<span class="text-[#fde68a]">Skeleton</span>&gt;
+  )
+}`} />
+          </div>
+          <div>
+            <p className="text-[13px] font-medium text-stone-500 mb-2">3. Generate bones</p>
+            <CodeBlock language="bash" code="npx boneyard-js build" />
+            <p className="text-[13px] text-stone-400 mt-2">
+              Auto-detects your Preact dev server and captures all named skeletons.
+            </p>
+          </div>
+          <div>
+            <p className="text-[13px] font-medium text-stone-500 mb-2">4. Import the registry</p>
+            <CodeBlock language="ts" code={`<span class="text-stone-500">// Add once in your app entry (e.g. main.tsx)</span>
+<span class="text-[#c084fc]">import</span> <span class="text-[#86efac]">'./bones/registry'</span>`} />
+            <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+              <p className="text-[13px] text-amber-700">
+                <strong className="text-amber-800">This import is required.</strong> Without it, skeletons won&apos;t render — the component
+                needs the registry to resolve bone data by name.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Props */}
+      <section>
+        <div className="section-divider" id="props">
+          <span>Props</span>
+        </div>
+        <div className="mt-4 rounded-lg border border-stone-200 overflow-hidden">
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="bg-stone-50 border-b border-stone-200">
+                <th className="text-left px-4 py-2 font-medium text-stone-700">Prop</th>
+                <th className="text-left px-4 py-2 font-medium text-stone-700">Type</th>
+                <th className="text-left px-4 py-2 font-medium text-stone-700">Default</th>
+                <th className="text-left px-4 py-2 font-medium text-stone-700">Description</th>
+              </tr>
+            </thead>
+            <tbody className="text-[#78716c]">
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">loading</td>
+                <td className="px-4 py-2">boolean</td>
+                <td className="px-4 py-2">required</td>
+                <td className="px-4 py-2">Show skeleton or children</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">name</td>
+                <td className="px-4 py-2">string</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">Resolve bones from registry by name</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">initialBones</td>
+                <td className="px-4 py-2">ResponsiveBones</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">Pass bones directly (overrides registry)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">color</td>
+                <td className="px-4 py-2">string</td>
+                <td className="px-4 py-2">rgba(0,0,0,0.08)</td>
+                <td className="px-4 py-2">Bone color in light mode</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">darkColor</td>
+                <td className="px-4 py-2">string</td>
+                <td className="px-4 py-2">rgba(255,255,255,0.06)</td>
+                <td className="px-4 py-2">Bone color in dark mode</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">animate</td>
+                <td className="px-4 py-2">{`'pulse' | 'shimmer' | 'solid'`}</td>
+                <td className="px-4 py-2">pulse</td>
+                <td className="px-4 py-2">Animation style (also accepts true/false)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">stagger</td>
+                <td className="px-4 py-2">number | boolean</td>
+                <td className="px-4 py-2">false</td>
+                <td className="px-4 py-2">Stagger delay between bones in ms (true = 80ms)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">transition</td>
+                <td className="px-4 py-2">number | boolean</td>
+                <td className="px-4 py-2">false</td>
+                <td className="px-4 py-2">Fade out duration in ms when loading ends (true = 300ms)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">boneClass</td>
+                <td className="px-4 py-2">string</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">CSS class applied to each bone element</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">className</td>
+                <td className="px-4 py-2">string</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">CSS class on the container</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">fixture</td>
+                <td className="px-4 py-2">ComponentChildren</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">Mock content for CLI capture (dev only)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">fallback</td>
+                <td className="px-4 py-2">ComponentChildren</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">Shown when loading but no bones available</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 font-mono text-stone-800">snapshotConfig</td>
+                <td className="px-4 py-2">SnapshotConfig</td>
+                <td className="px-4 py-2">—</td>
+                <td className="px-4 py-2">Controls bone extraction during CLI capture</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Vite plugin */}
+      <section>
+        <div className="section-divider" id="vite-plugin">
+          <span>Vite plugin</span>
+        </div>
+        <p className="text-[14px] text-[#78716c] leading-relaxed mt-4 mb-4">
+          The Vite plugin auto-detects Preact and generates the registry with the correct imports. No extra configuration needed:
+        </p>
+        <CodeBlock filename="vite.config.ts" language="ts" code={`<span class="text-[#c084fc]">import</span> { defineConfig } <span class="text-[#c084fc]">from</span> <span class="text-[#86efac]">'vite'</span>
+<span class="text-[#c084fc]">import</span> preact <span class="text-[#c084fc]">from</span> <span class="text-[#86efac]">'@preact/preset-vite'</span>
+<span class="text-[#c084fc]">import</span> { boneyardPlugin } <span class="text-[#c084fc]">from</span> <span class="text-[#86efac]">'boneyard-js/vite'</span>
+
+<span class="text-[#c084fc]">export default</span> <span class="text-[#fde68a]">defineConfig</span>({
+  <span class="text-[#93c5fd]">plugins</span>: [<span class="text-[#fde68a]">preact</span>(), <span class="text-[#fde68a]">boneyardPlugin</span>()]
+})`} />
+        <p className="text-[13px] text-stone-400 mt-2">
+          Bones are captured on dev server start and re-captured on every HMR update.
+        </p>
+      </section>
+
+      {/* Dark mode */}
+      <section>
+        <div className="section-divider" id="dark-mode">
+          <span>Dark mode</span>
+        </div>
+        <p className="text-[14px] text-[#78716c] leading-relaxed mt-4 mb-4">
+          Auto-detects via <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">.dark</code> class
+          on <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">{'<html>'}</code> or any parent element (Tailwind convention),
+          and <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">prefers-color-scheme</code> media query.
+          Uses <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">darkColor</code> when dark mode is active.
+        </p>
+      </section>
+
+      {/* Animations */}
+      <section>
+        <div className="section-divider" id="animations">
+          <span>Animations</span>
+        </div>
+        <div className="mt-4 rounded-lg border border-stone-200 overflow-hidden">
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="bg-stone-50 border-b border-stone-200">
+                <th className="text-left px-4 py-2 font-medium text-stone-700">Value</th>
+                <th className="text-left px-4 py-2 font-medium text-stone-700">Effect</th>
+              </tr>
+            </thead>
+            <tbody className="text-[#78716c]">
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">{`'pulse'`}</td>
+                <td className="px-4 py-2">Fades a lighter overlay in and out (1.8s cycle)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">{`'shimmer'`}</td>
+                <td className="px-4 py-2">Sweeps a gradient highlight across each bone (2.4s cycle)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 font-mono text-stone-800">{`'solid'`}</td>
+                <td className="px-4 py-2">Static — no animation</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 font-mono text-stone-800">true / false</td>
+                <td className="px-4 py-2">true = pulse, false = solid</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Global defaults */}
+      <section>
+        <div className="section-divider" id="global-defaults">
+          <span>Global defaults</span>
+        </div>
+        <p className="text-[14px] text-[#78716c] leading-relaxed mt-4 mb-4">
+          Set defaults for all skeletons with <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">configureBoneyard()</code>:
+        </p>
+        <CodeBlock language="tsx" code={`<span class="text-[#c084fc]">import</span> { configureBoneyard } <span class="text-[#c084fc]">from</span> <span class="text-[#86efac]">'boneyard-js/preact'</span>
+
+<span class="text-[#fde68a]">configureBoneyard</span>({
+  <span class="text-[#93c5fd]">color</span>: <span class="text-[#86efac]">'#e5e5e5'</span>,
+  <span class="text-[#93c5fd]">darkColor</span>: <span class="text-[#86efac]">'rgba(255,255,255,0.08)'</span>,
+  <span class="text-[#93c5fd]">animate</span>: <span class="text-[#86efac]">'shimmer'</span>,
+})`} />
+        <p className="text-[13px] text-stone-400 mt-2">
+          Per-component props override global defaults.
+        </p>
+      </section>
+
+      {/* Config file */}
+      <section>
+        <div className="section-divider" id="config-file">
+          <span>Config file</span>
+        </div>
+        <p className="text-[14px] text-[#78716c] leading-relaxed mt-4">
+          See <a href="/install#config-file" className="text-stone-800 underline underline-offset-2">Install &rarr; Config file</a> for
+          the full <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">boneyard.config.json</code> reference. Works with all frameworks.
+        </p>
+      </section>
+
+      {/* Next steps */}
+      <section>
+        <div className="rounded-lg border border-stone-200 bg-stone-50 p-4">
+          <p className="text-[13px] font-medium text-stone-700 mb-2">Next steps</p>
+          <ul className="text-[13px] text-[#78716c] space-y-1 list-disc pl-4">
+            <li>See <a href="/install" className="text-stone-800 underline underline-offset-2">Getting Started</a> for the full web setup walkthrough</li>
+            <li>See <a href="/output" className="text-stone-800 underline underline-offset-2">Output</a> to understand the .bones.json format</li>
+            <li>See <a href="/features" className="text-stone-800 underline underline-offset-2">CLI &amp; Props Reference</a> for all flags and options</li>
+          </ul>
+        </div>
+      </section>
+    </div>
+
+    <TableOfContents items={tocItems} />
+    </div>
+  );
+}

--- a/apps/docs/src/components/sidebar.tsx
+++ b/apps/docs/src/components/sidebar.tsx
@@ -20,6 +20,7 @@ const gettingStarted = [
 
 const frameworkGuides = [
   { href: "/features", label: "React" },
+  { href: "/preact", label: "Preact" },
   { href: "/react-native", label: "React Native" },
   { href: "/svelte", label: "Svelte" },
   { href: "/vue", label: "Vue" },

--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -840,13 +840,14 @@ function detectFramework() {
       if (allDeps['vue'] || allDeps['nuxt']) return 'vue'
       if (allDeps['svelte'] || allDeps['@sveltejs/kit']) return 'svelte'
       if (allDeps['@angular/core']) return 'angular'
+      if (allDeps['preact']) return 'preact'
     }
   } catch {}
   return 'react'
 }
 const detectedFramework = detectFramework()
 // registerBones lives in boneyard-js (shared). configureBoneyard is framework-specific.
-const frameworkPaths = { react: 'boneyard-js/react', vue: 'boneyard-js/vue', native: 'boneyard-js/native', svelte: 'boneyard-js/svelte', angular: 'boneyard-js/angular' }
+const frameworkPaths = { react: 'boneyard-js/react', vue: 'boneyard-js/vue', native: 'boneyard-js/native', svelte: 'boneyard-js/svelte', angular: 'boneyard-js/angular', preact: 'boneyard-js/preact' }
 const registryImportPath = 'boneyard-js'
 const configImportPath = frameworkPaths[detectedFramework] || 'boneyard-js/react'
 const registryLines = [

--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -40,6 +40,11 @@
       "types": "./dist/native-scan.d.ts",
       "default": "./dist/native-scan.tsx"
     },
+    "./preact": {
+      "types": "./dist/preact.d.ts",
+      "import": "./dist/preact.tsx",
+      "default": "./dist/preact.tsx"
+    },
     "./angular": {
       "types": "./dist/angular.d.ts",
       "default": "./dist/angular.ts"
@@ -66,6 +71,9 @@
       "vue": [
         "./dist/vue.d.ts"
       ],
+      "preact": [
+        "./dist/preact.d.ts"
+      ],
       "angular": [
         "./dist/angular.d.ts"
       ],
@@ -86,10 +94,11 @@
     "native-scan.d.ts"
   ],
   "scripts": {
-    "build": "tsc && npm run copy-svelte && npm run copy-native && npm run copy-vue && npm run copy-angular",
+    "build": "tsc && npm run copy-svelte && npm run copy-native && npm run copy-vue && npm run copy-preact && npm run copy-angular",
     "copy-svelte": "cp src/Skeleton.svelte dist/Skeleton.svelte && cp src/svelte.d.ts dist/svelte.d.ts",
     "copy-native": "cp src/native.tsx dist/native.tsx && cp src/react-native.tsx dist/react-native.tsx && cp src/native-scan.tsx dist/native-scan.tsx",
     "copy-vue": "cp src/Skeleton.vue dist/Skeleton.vue && cp src/vue.d.ts dist/vue.d.ts",
+    "copy-preact": "cp src/preact.tsx dist/preact.tsx && cp src/preact.d.ts dist/preact.d.ts",
     "copy-angular": "cp src/angular.ts dist/angular.ts && cp src/angular.d.ts dist/angular.d.ts",
     "benchmark": "bun run scripts/benchmark-layout.ts",
     "test": "bun test",
@@ -103,6 +112,7 @@
     "react",
     "react-native",
     "vue",
+    "preact",
     "angular",
     "vite",
     "vite-plugin",
@@ -122,6 +132,7 @@
     "react-native": ">=0.71",
     "svelte": ">=5.29",
     "vue": ">=3",
+    "preact": ">=10",
     "@angular/core": ">=14",
     "vite": ">=5"
   },
@@ -136,6 +147,9 @@
       "optional": true
     },
     "vue": {
+      "optional": true
+    },
+    "preact": {
       "optional": true
     },
     "@angular/core": {

--- a/packages/boneyard/src/preact.d.ts
+++ b/packages/boneyard/src/preact.d.ts
@@ -1,0 +1,33 @@
+import type { ComponentChildren } from 'preact'
+import type { ResponsiveBones, SkeletonResult, SnapshotConfig } from './types.js'
+
+export type AnimationStyle = 'pulse' | 'shimmer' | 'solid' | boolean
+
+export { registerBones } from './shared.js'
+export function configureBoneyard(config: {
+  color?: string
+  darkColor?: string
+  animate?: AnimationStyle
+  stagger?: number | boolean
+  transition?: number | boolean
+  boneClass?: string
+}): void
+
+export interface SkeletonProps {
+  loading: boolean
+  children: ComponentChildren
+  name?: string
+  initialBones?: SkeletonResult | ResponsiveBones
+  color?: string
+  darkColor?: string
+  animate?: AnimationStyle
+  stagger?: number | boolean
+  transition?: number | boolean
+  boneClass?: string
+  className?: string
+  fallback?: ComponentChildren
+  fixture?: ComponentChildren
+  snapshotConfig?: SnapshotConfig
+}
+
+export function Skeleton(props: SkeletonProps): ComponentChildren

--- a/packages/boneyard/src/preact.tsx
+++ b/packages/boneyard/src/preact.tsx
@@ -1,0 +1,287 @@
+/** @jsxImportSource preact */
+import { useRef, useState, useEffect } from 'preact/hooks'
+import type { ComponentChildren } from 'preact'
+import { normalizeBone } from './types.js'
+import type { AnyBone, SkeletonResult, ResponsiveBones, SnapshotConfig } from './types.js'
+import {
+  adjustColor,
+  ensureBuildSnapshotHook,
+  getRegisteredBones,
+  isBuildMode,
+  registerBones,
+  resolveResponsive,
+} from './shared.js'
+
+ensureBuildSnapshotHook()
+
+export { registerBones }
+
+// ── Global defaults ─────────────────────────────────────────────────────────
+export type AnimationStyle = 'pulse' | 'shimmer' | 'solid' | boolean
+
+interface BoneyardConfig {
+  color?: string
+  darkColor?: string
+  animate?: AnimationStyle
+  stagger?: number | boolean
+  transition?: number | boolean
+  boneClass?: string
+}
+
+let globalConfig: BoneyardConfig = {}
+
+/**
+ * Set global defaults for all `<Skeleton>` components.
+ * Individual props override these defaults.
+ *
+ * ```ts
+ * import { configureBoneyard } from 'boneyard-js/preact'
+ *
+ * configureBoneyard({
+ *   color: '#e5e5e5',
+ *   darkColor: 'rgba(255,255,255,0.08)',
+ *   animate: true,
+ * })
+ * ```
+ */
+export function configureBoneyard(config: BoneyardConfig): void {
+  globalConfig = { ...globalConfig, ...config }
+}
+
+export interface SkeletonProps {
+  /** When true, shows the skeleton. When false, shows children. */
+  loading: boolean
+  /** Your component — rendered when not loading. */
+  children: ComponentChildren
+  /**
+   * Name this skeleton. Used by `npx boneyard-js build` to identify and capture bones.
+   * Also used to auto-resolve pre-generated bones from the registry.
+   */
+  name?: string
+  /**
+   * Pre-generated bones. Accepts a single `SkeletonResult` or a `ResponsiveBones` map.
+   */
+  initialBones?: SkeletonResult | ResponsiveBones
+  /** Bone color (default: 'rgba(0,0,0,0.08)', auto-detects dark mode) */
+  color?: string
+  /** Bone color for dark mode (default: 'rgba(255,255,255,0.06)'). Used when prefers-color-scheme is dark or a .dark ancestor exists. */
+  darkColor?: string
+  /** Animation style: 'pulse' (default), 'shimmer', 'solid', or boolean (true = pulse, false = solid) */
+  animate?: AnimationStyle
+  /** Stagger animation delay between bones in ms (default: false, true = 80ms) */
+  stagger?: number | boolean
+  /** Fade transition duration in ms when skeleton hides (default: false, true = 300ms) */
+  transition?: number | boolean
+  /** CSS class applied to each bone element */
+  boneClass?: string
+  /** Additional className for the container */
+  className?: string
+  /**
+   * Shown when loading is true and no bones are available.
+   */
+  fallback?: ComponentChildren
+  /**
+   * Mock content rendered during `npx boneyard-js build` so the CLI can capture
+   * bone positions even when real data isn't available.
+   * Only rendered when the CLI sets `window.__BONEYARD_BUILD = true`.
+   */
+  fixture?: ComponentChildren
+  /**
+   * Controls how `npx boneyard-js build` extracts bones from the fixture.
+   * Stored as a data attribute — the CLI reads it during capture.
+   */
+  snapshotConfig?: SnapshotConfig
+}
+
+/**
+ * Wrap any component to get automatic skeleton loading screens.
+ *
+ * 1. Run `npx boneyard-js build` — captures bone positions from your rendered UI
+ * 2. Import the generated registry in your app entry
+ * 3. `<Skeleton name="..." loading={isLoading}>` auto-resolves bones by name
+ */
+export function Skeleton({
+  loading,
+  children,
+  name,
+  initialBones,
+  color,
+  darkColor,
+  animate,
+  stagger = false,
+  transition = false,
+  boneClass,
+  className,
+  fallback,
+  fixture,
+  snapshotConfig,
+}: SkeletonProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const uid = useRef(Math.random().toString(36).slice(2, 8)).current
+  const [containerWidth, setContainerWidth] = useState(0)
+  const [containerHeight, setContainerHeight] = useState(0)
+  const [isDark, setIsDark] = useState(false)
+
+  // Auto-detect dark mode (watches both prefers-color-scheme and .dark class)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const checkDark = () => {
+      const hasDarkClass = document.documentElement.classList.contains('dark') ||
+        !!containerRef.current?.closest('.dark')
+      setIsDark(hasDarkClass)
+    }
+    checkDark()
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const mqHandler = () => checkDark()
+    mq.addEventListener('change', mqHandler)
+    // Watch for .dark class changes on <html>
+    const mo = new MutationObserver(checkDark)
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => {
+      mq.removeEventListener('change', mqHandler)
+      mo.disconnect()
+    }
+  }, [])
+
+  const effectiveColor = color ?? globalConfig.color ?? 'rgba(0,0,0,0.08)'
+  const effectiveDarkColor = darkColor ?? globalConfig.darkColor ?? 'rgba(255,255,255,0.06)'
+  const resolvedColor = isDark ? effectiveDarkColor : effectiveColor
+  const rawAnimate = animate ?? globalConfig.animate ?? 'pulse'
+  const animationStyle: 'pulse' | 'shimmer' | 'solid' =
+    rawAnimate === true ? 'pulse' :
+    rawAnimate === false ? 'solid' :
+    rawAnimate
+
+  // Track container width for responsive breakpoint selection
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const ro = new ResizeObserver(entries => {
+      const rect = entries[0]?.contentRect
+      setContainerWidth(Math.round(rect?.width ?? 0))
+      if (rect && rect.height > 0) setContainerHeight(Math.round(rect.height))
+    })
+    ro.observe(el)
+    const rect = el.getBoundingClientRect()
+    setContainerWidth(Math.round(rect.width))
+    if (rect.height > 0) setContainerHeight(Math.round(rect.height))
+    return () => ro.disconnect()
+  }, [])
+
+  // Data attributes for CLI discovery
+  const dataAttrs: Record<string, string> = {}
+  if (name) {
+    dataAttrs['data-boneyard'] = name
+    if (snapshotConfig) {
+      dataAttrs['data-boneyard-config'] = JSON.stringify(snapshotConfig)
+    }
+  }
+
+  // Build mode: render fixture (if provided) or children so CLI can capture bones
+  if (isBuildMode()) {
+    return (
+      <div ref={containerRef} className={className} style={{ position: 'relative' }} {...dataAttrs}>
+        <div>{fixture ?? children}</div>
+      </div>
+    )
+  }
+
+  // Resolve bones: explicit initialBones > registry lookup
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => { setMounted(true) }, [])
+
+  const effectiveBones = initialBones ?? (name ? getRegisteredBones(name) : undefined)
+  const viewportWidth = mounted && typeof window !== 'undefined' ? window.innerWidth : 0
+  const resolveWidth = containerWidth > 0 ? containerWidth : viewportWidth
+  const activeBones = effectiveBones && resolveWidth > 0
+    ? resolveResponsive(effectiveBones, resolveWidth)
+    : null
+
+  const resolvedBoneClass = boneClass ?? globalConfig.boneClass
+
+  // Stagger: delay between each bone's animation
+  const staggerMs = (() => { const v = stagger ?? globalConfig.stagger; return v === true ? 80 : v === false || !v ? 0 : v })()
+
+  // Transition: fade out skeleton when loading ends
+  const transitionMs = (() => { const v = transition ?? globalConfig.transition; return v === true ? 300 : v === false || !v ? 0 : v })()
+  const [transitioning, setTransitioning] = useState(false)
+  const prevLoadingRef = useRef(loading)
+  const transitionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (prevLoadingRef.current && !loading && transitionMs > 0 && activeBones) {
+      if (transitionTimerRef.current) clearTimeout(transitionTimerRef.current)
+      setTransitioning(true)
+      transitionTimerRef.current = setTimeout(() => {
+        setTransitioning(false)
+        transitionTimerRef.current = null
+      }, transitionMs)
+    }
+    prevLoadingRef.current = loading
+    return () => {
+      if (transitionTimerRef.current) clearTimeout(transitionTimerRef.current)
+    }
+  }, [loading, transitionMs, activeBones])
+
+  const showSkeleton = (loading || transitioning) && activeBones
+  const showFallback = loading && !activeBones && !transitioning
+
+  // Scale vertical positions to match actual container height
+  const effectiveHeight = containerHeight > 0 ? containerHeight : activeBones?.height ?? 0
+  const capturedHeight = activeBones?.height ?? 0
+  const scaleY = (effectiveHeight > 0 && capturedHeight > 0) ? effectiveHeight / capturedHeight : 1
+
+  return (
+    <div ref={containerRef} className={className} style={{ position: 'relative' }} {...dataAttrs}>
+      <div data-boneyard-content="true" style={showSkeleton && !transitioning ? { visibility: 'hidden' } : undefined}>
+        {showFallback ? fallback : children}
+      </div>
+
+      {showSkeleton && (
+        <div data-boneyard-overlay="true" style={{
+          position: 'absolute', inset: 0, overflow: 'hidden',
+          opacity: transitioning ? 0 : 1,
+          transition: transitionMs > 0 ? `opacity ${transitionMs}ms ease-out` : undefined,
+        }}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            {(activeBones.bones as AnyBone[]).map((raw, i) => {
+              const b = normalizeBone(raw)
+              const boneColor = b.c ? adjustColor(resolvedColor, isDark ? 0.03 : 0.45) : resolvedColor
+              const lighterColor = adjustColor(resolvedColor, isDark ? 0.04 : 0.3)
+              const boneStyle: Record<string, any> = {
+                position: 'absolute',
+                left: `${b.x}%`,
+                top: b.y * scaleY,
+                width: `${b.w}%`,
+                height: b.h * scaleY,
+                borderRadius: typeof b.r === 'string' ? b.r : `${b.r}px`,
+                backgroundColor: boneColor,
+              }
+              if (animationStyle === 'pulse') {
+                boneStyle.animation = `bp-${uid} 1.8s ease-in-out infinite`
+              } else if (animationStyle === 'shimmer') {
+                boneStyle.background = `linear-gradient(90deg, ${boneColor} 30%, ${lighterColor} 50%, ${boneColor} 70%)`
+                boneStyle.backgroundSize = '200% 100%'
+                boneStyle.animation = `bs-${uid} 2.4s linear infinite`
+              }
+              if (staggerMs > 0) {
+                boneStyle.opacity = 0
+                boneStyle.animation = `${boneStyle.animation ? boneStyle.animation + ',' : ''} by-${uid} 0.3s ease-out ${i * staggerMs}ms forwards`
+              }
+              return <div key={i} data-boneyard-bone="true" className={resolvedBoneClass} style={boneStyle} />
+            })}
+            {animationStyle === 'pulse' && (
+              <style>{`@keyframes bp-${uid}{0%,100%{background-color:${resolvedColor}}50%{background-color:${adjustColor(resolvedColor, isDark ? 0.04 : 0.3)}}}`}</style>
+            )}
+            {animationStyle === 'shimmer' && (
+              <style>{`@keyframes bs-${uid}{0%{background-position:200% 0}100%{background-position:-200% 0}}`}</style>
+            )}
+            {staggerMs > 0 && (
+              <style>{`@keyframes by-${uid}{from{opacity:0}to{opacity:1}}`}</style>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/boneyard/src/vite.d.ts
+++ b/packages/boneyard/src/vite.d.ts
@@ -8,7 +8,7 @@ export interface BoneyardPluginOptions {
   /** Extra ms to wait after page load (default: 800) */
   wait?: number
   /** Framework for registry imports (default: auto-detected) */
-  framework?: 'react' | 'vue' | 'svelte'
+  framework?: 'react' | 'vue' | 'svelte' | 'preact'
   /** Skip initial capture on server start (default: false) */
   skipInitial?: boolean
   /** Connect to existing Chrome via debug port instead of launching Playwright */

--- a/packages/boneyard/src/vite.ts
+++ b/packages/boneyard/src/vite.ts
@@ -28,7 +28,7 @@ export interface BoneyardPluginOptions {
   /** Extra ms to wait after page load (default: 800) */
   wait?: number
   /** Framework for registry imports (default: auto-detected) */
-  framework?: 'react' | 'vue' | 'svelte'
+  framework?: 'react' | 'vue' | 'svelte' | 'preact'
   /** Skip initial capture on server start (default: false) */
   skipInitial?: boolean
   /** Connect to existing Chrome via debug port instead of launching Playwright */
@@ -70,6 +70,7 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
         const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
         if (allDeps['vue'] || allDeps['nuxt']) return 'vue'
         if (allDeps['svelte'] || allDeps['@sveltejs/kit']) return 'svelte'
+        if (allDeps['preact']) return 'preact'
       }
     } catch {}
     return 'react'
@@ -184,6 +185,7 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       // Generate registry
       const registryImportPath = fw === 'vue' ? 'boneyard-js/vue'
         : fw === 'svelte' ? 'boneyard-js/svelte'
+        : fw === 'preact' ? 'boneyard-js/preact'
         : 'boneyard-js/react'
       const registryLines = [
         ...(fw === 'react' ? ['"use client"'] : []),

--- a/packages/boneyard/tsconfig.json
+++ b/packages/boneyard/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
-  "exclude": ["src/**/*.test.ts", "src/test-*.ts", "src/native.tsx", "src/react-native.tsx", "src/angular.ts"]
+  "exclude": ["src/**/*.test.ts", "src/test-*.ts", "src/native.tsx", "src/react-native.tsx", "src/preact.tsx", "src/angular.ts"]
 }


### PR DESCRIPTION
- Added boneyard-js/preact export using native Preact APIs (preact/hooks, ComponentChildren) — no preact/compat required
- Full feature parity with React: dark mode detection, responsive bones, stagger, transition, boneClass
- CLI and Vite plugin auto-detect Preact projects from package.json and generate registry with correct boneyard-js/preact imports
- Added Preact to framework type union in Vite plugin options
- Added /preact docs page, sidebar nav link, README examples, exports table, llms.txt, and agent page

Fixes #44 