### PR TITLE
Adapt RN skeletons to Dynamic Type / font scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ npx boneyard-js build --native --out ./bones
 # Open your app on device — bones capture automatically
 ```
 
+> **Dynamic Type:** Generate bones at default font scale. Boneyard automatically scales bone positions at runtime to match the user's text size setting.
+
 ## Generate bones
 
 ```bash

--- a/apps/docs/src/app/agent/llms.txt/route.ts
+++ b/apps/docs/src/app/agent/llms.txt/route.ts
@@ -229,6 +229,8 @@ import { Skeleton } from 'boneyard-js/native'
 
 Generate bones: \`npx boneyard-js build --native --out ./bones\`, then open your app on device. The Skeleton component auto-scans in dev mode via fiber tree + UIManager. In production, scan code is inactive.
 
+**Dynamic Type:** Always generate bones at default font scale (1.0). At runtime, boneyard renders children invisibly behind the skeleton overlay to measure the real content height, then scales bone positions proportionally via \`scaleY\`. This handles iOS Dynamic Type and Android font scaling automatically — no need to capture at multiple sizes.
+
 Auth is a non-issue — the app is already running with the user logged in.
 
 ## Svelte

--- a/apps/docs/src/app/agent/page.tsx
+++ b/apps/docs/src/app/agent/page.tsx
@@ -205,6 +205,8 @@ import { Skeleton } from 'boneyard-js/native'
 
 Generate bones: \`npx boneyard-js build --native --out ./bones\`, then open your app on device. The Skeleton component auto-scans in dev mode — walks the React fiber tree, measures each view via UIManager, and sends bone data to the CLI. In production, scan code is completely inactive.
 
+**Dynamic Type:** Always generate bones at default font scale (1.0). At runtime, boneyard renders children invisibly behind the skeleton overlay to measure the real content height, then scales bone positions proportionally via \`scaleY\`. This handles iOS Dynamic Type and Android font scaling automatically — no need to capture at multiple sizes.
+
 After generating, add \`import './bones/registry'\` and reload the app.
 
 ## Svelte

--- a/apps/docs/src/app/react-native/page.tsx
+++ b/apps/docs/src/app/react-native/page.tsx
@@ -4,6 +4,7 @@ import { TableOfContents } from "@/components/toc";
 const tocItems = [
   { id: "quick-start", label: "Quick start" },
   { id: "how-scanning-works", label: "How scanning works" },
+  { id: "dynamic-type", label: "Dynamic Type" },
   { id: "other-ways", label: "Other ways to generate" },
   { id: "props", label: "Props" },
   { id: "dark-mode", label: "Dark mode" },
@@ -107,6 +108,31 @@ export default function ReactNativePage() {
             Shake your device and tap &quot;Reload&quot;, or press <code className="text-[12px] bg-amber-100 px-1 py-0.5 rounded">r</code> in the Expo terminal.
           </p>
         </div>
+      </section>
+
+      {/* Dynamic Type */}
+      <section>
+        <div className="section-divider" id="dynamic-type">
+          <span>Dynamic Type &amp; accessibility text sizing</span>
+        </div>
+        <p className="text-[14px] text-[#78716c] leading-relaxed mt-4 mb-4">
+          Boneyard adapts to iOS Dynamic Type and Android font scaling at runtime. When a user changes their
+          text size, the actual content grows or shrinks — boneyard detects the new container height and
+          scales bone positions proportionally to match.
+        </p>
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <p className="text-[13px] font-medium text-amber-800 mb-1">Generate bones at default font scale</p>
+          <p className="text-[13px] text-amber-700">
+            Always capture bones with your device set to the <strong>default</strong> text size (font scale 1.0).
+            The skeleton automatically scales bone positions up or down at runtime to match the user&apos;s
+            actual font scale — no need to capture at multiple sizes.
+          </p>
+        </div>
+        <p className="text-[13px] text-stone-400 mt-3">
+          Under the hood, children are rendered invisibly behind the skeleton overlay so the container
+          reflects the real content height. A <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">scaleY</code> ratio
+          adjusts all bone Y positions and heights to fit.
+        </p>
       </section>
 
       {/* Other ways to get bones */}
@@ -389,6 +415,11 @@ module.exports = config`} />
                 <td className="px-4 py-2 text-stone-800">Responsive</td>
                 <td className="px-4 py-2">ResizeObserver on container</td>
                 <td className="px-4 py-2">useWindowDimensions (screen width)</td>
+              </tr>
+              <tr className="border-b border-stone-100">
+                <td className="px-4 py-2 text-stone-800">Text scaling</td>
+                <td className="px-4 py-2">N/A (browser handles it)</td>
+                <td className="px-4 py-2">scaleY adapts to Dynamic Type / font scale</td>
               </tr>
               <tr>
                 <td className="px-4 py-2 text-stone-800">Bone format</td>

--- a/packages/boneyard/src/native.tsx
+++ b/packages/boneyard/src/native.tsx
@@ -443,9 +443,10 @@ export function Skeleton({
   const isDark = dark ?? systemScheme === 'dark'
 
   const [containerWidth, setContainerWidth] = useState(0)
+  const [containerHeight, setContainerHeight] = useState(0)
   const containerRef = useRef<View>(null)
   const hasScanned = useRef(false)
-  const { width: screenWidth } = useWindowDimensions()
+  const { width: screenWidth, fontScale } = useWindowDimensions()
 
   const effectiveColor = color ?? globalConfig.color ?? (isDark ? '#3a3a3c' : '#d4d4d4')
   const effectiveDarkColor = darkColor ?? globalConfig.darkColor ?? '#3a3a3c'
@@ -461,11 +462,13 @@ export function Skeleton({
   const shimmerAnim = useShimmerAnimation(loading && animationStyle === 'shimmer')
 
   const onLayout = useCallback((e: LayoutChangeEvent) => {
-    const { width } = e.nativeEvent.layout
+    const { width, height } = e.nativeEvent.layout
     setContainerWidth(Math.round(width))
+    if (height > 0) setContainerHeight(Math.round(height))
   }, [])
 
   // Dev scan — when CLI is running, auto-capture bones from children
+  // Re-scans when fontScale changes so bones match Dynamic Type sizing
   useEffect(() => {
     if (typeof __DEV__ === 'undefined' || !__DEV__ || !name || hasScanned.current) return
     hasScanned.current = true
@@ -475,7 +478,7 @@ export function Skeleton({
       }
     }, 800)
     return () => clearTimeout(timer)
-  }, [name, screenWidth])
+  }, [name, screenWidth, fontScale])
 
   const effectiveBones = initialBones ?? (name ? bonesRegistry.get(name) : undefined)
   const activeBones = effectiveBones
@@ -511,12 +514,21 @@ export function Skeleton({
 
   const showSkeleton = (loading || transitioning) && activeBones
   const showFallback = loading && !activeBones && !transitioning
-  const boneHeight = activeBones?.height ?? 0
+
+  // Scale vertical positions to match actual container height (handles Dynamic Type / font scaling)
+  const capturedHeight = activeBones?.height ?? 0
+  const effectiveHeight = containerHeight > 0 ? containerHeight : capturedHeight
+  const scaleY = (effectiveHeight > 0 && capturedHeight > 0) ? effectiveHeight / capturedHeight : 1
 
   return (
     <View ref={containerRef} style={[styles.container, style]} onLayout={onLayout} collapsable={false}>
-      {showSkeleton ? (
-        <Animated.View style={{ width: '100%', height: boneHeight, opacity: transitioning ? fadeAnim : 1 }}>
+      {/* Always render children so the container reflects real content height (handles Dynamic Type) */}
+      <View style={showSkeleton && !transitioning ? styles.hidden : undefined} pointerEvents={showSkeleton ? 'none' : 'auto'}>
+        {showFallback ? fallback ?? null : children}
+      </View>
+
+      {showSkeleton && (
+        <Animated.View style={[StyleSheet.absoluteFill, { opacity: transitioning ? fadeAnim : 1 }]}>
           {activeBones.bones.map((raw: AnyBone, i: number) => {
             const b = normalizeBone(raw)
             const borderRadius = typeof b.r === 'number'
@@ -539,9 +551,9 @@ export function Skeleton({
                 style={{
                   position: 'absolute',
                   left: `${b.x}%`,
-                  top: b.y,
+                  top: b.y * scaleY,
                   width: `${b.w}%`,
-                  height: b.h,
+                  height: b.h * scaleY,
                   borderRadius,
                   backgroundColor: boneColor,
                   overflow: 'hidden',
@@ -576,10 +588,6 @@ export function Skeleton({
             )
           })}
         </Animated.View>
-      ) : showFallback ? (
-        fallback ?? null
-      ) : (
-        children
       )}
     </View>
   )
@@ -588,5 +596,8 @@ export function Skeleton({
 const styles = StyleSheet.create({
   container: {
     position: 'relative',
+  },
+  hidden: {
+    opacity: 0,
   },
 })


### PR DESCRIPTION
## Changes
- Render children invisibly behind the skeleton overlay so the container reflects real content height
- Compute scaleY from actual vs captured height to scale bone positions proportionally at runtime
- Handles iOS Dynamic Type and Android font scaling without needing to capture at multiple font sizes
- Bones should be generated at default font scale (1.0) — documented in README, RN docs page,
  llms.txt, and agent page

## Demo

https://github.com/user-attachments/assets/d1490492-273c-4173-ad76-7619f3068f72

