### PR TITLE
feat(cli): detect ts/js registry filename

### DIFF
--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -26,6 +26,7 @@ import { writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync } from 
 import { resolve, join, dirname } from 'path'
 import http from 'http'
 import https from 'https'
+import { detectRegistryExtension } from './registry-file.js'
 
 function loadEnvFile(filePath) {
   if (!existsSync(filePath)) {
@@ -921,6 +922,8 @@ function detectFramework() {
   return 'react'
 }
 const detectedFramework = detectFramework()
+const registryExtension = detectRegistryExtension()
+const registryFilename = `registry.${registryExtension}`
 // registerBones lives in boneyard-js (shared). configureBoneyard is framework-specific.
 const frameworkPaths = { react: 'boneyard-js/react', vue: 'boneyard-js/vue', native: 'boneyard-js/native', svelte: 'boneyard-js/svelte', angular: 'boneyard-js/angular', preact: 'boneyard-js/preact' }
 const registryImportPath = 'boneyard-js'
@@ -962,9 +965,9 @@ for (const name of names) {
 registryLines.push('})')
 registryLines.push('')
 
-const registryPath = join(outputDir, 'registry.js')
+const registryPath = join(outputDir, registryFilename)
 writeFileSync(registryPath, registryLines.join('\n'))
-console.log(`  \x1b[32m→\x1b[0m registry.js  \x1b[2m(${names.length} skeleton${names.length !== 1 ? 's' : ''})\x1b[0m`)
+console.log(`  \x1b[32m→\x1b[0m ${registryFilename}  \x1b[2m(${names.length} skeleton${names.length !== 1 ? 's' : ''})\x1b[0m`)
 
 const count = names.length
 const skippedCount = skippedSkeletons.size
@@ -1034,7 +1037,7 @@ if (watchMode && !nativeMode) {
     }
     wRegistryLines.push('})')
     wRegistryLines.push('')
-    writeFileSync(join(outputDir, 'registry.js'), wRegistryLines.join('\n'))
+    writeFileSync(join(outputDir, registryFilename), wRegistryLines.join('\n'))
   }
 
   async function recapture() {
@@ -1200,9 +1203,11 @@ async function runScan() {
       registryLines.push('})')
       registryLines.push('')
 
-      const registryPath = join(scanOutDir, 'registry.js')
+      const scanRegistryExt = detectRegistryExtension()
+      const scanRegistryName = `registry.${scanRegistryExt}`
+      const registryPath = join(scanOutDir, scanRegistryName)
       writeFileSync(registryPath, registryLines.join('\n'))
-      console.log(`  \x1b[32m→\x1b[0m registry.js  \x1b[2m(${names.length} skeleton${names.length !== 1 ? 's' : ''})\x1b[0m`)
+      console.log(`  \x1b[32m→\x1b[0m ${scanRegistryName}  \x1b[2m(${names.length} skeleton${names.length !== 1 ? 's' : ''})\x1b[0m`)
 
       console.log(`\n  \x1b[32m\x1b[1m💀 ${names.length} skeleton${names.length !== 1 ? 's' : ''} captured.\x1b[0m\n`)
       console.log(`  \x1b[2mAdd once to your app entry:\x1b[0m  import '${scanOut}/registry'`)

--- a/packages/boneyard/bin/registry-file.d.ts
+++ b/packages/boneyard/bin/registry-file.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Detect whether the consumer project is TypeScript or JavaScript, so the
+ * CLI and Vite plugin can emit `registry.ts` vs `registry.js` consistently.
+ *
+ * Heuristics (first match wins):
+ *   1. `tsconfig.json` present  → 'ts'
+ *   2. `jsconfig.json` present  → 'js'
+ *   3. `next-env.d.ts` present  → 'ts'
+ *   4. `typescript` in (dev)deps → 'ts'
+ *   5. any .ts/.tsx/.mts/.cts source under src/app/pages/components/lib → 'ts'
+ *   6. fallback                 → 'js'
+ */
+export function detectRegistryExtension(projectRoot?: string): 'ts' | 'js'

--- a/packages/boneyard/bin/registry-file.js
+++ b/packages/boneyard/bin/registry-file.js
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync, readdirSync } from 'fs'
+import { join, resolve } from 'path'
+
+function hasFileWithExtensions(dir, extensions, depth = 0) {
+  if (depth > 3 || !existsSync(dir)) return false
+  let entries = []
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return false
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (hasFileWithExtensions(fullPath, extensions, depth + 1)) return true
+      continue
+    }
+    for (const ext of extensions) {
+      if (entry.name.endsWith(ext)) return true
+    }
+  }
+  return false
+}
+
+export function detectRegistryExtension(projectRoot = process.cwd()) {
+  if (existsSync(resolve(projectRoot, 'tsconfig.json'))) return 'ts'
+  if (existsSync(resolve(projectRoot, 'jsconfig.json'))) return 'js'
+  if (existsSync(resolve(projectRoot, 'next-env.d.ts'))) return 'ts'
+
+  try {
+    const pkgPath = resolve(projectRoot, 'package.json')
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+      const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+      if (allDeps.typescript) return 'ts'
+    }
+  } catch {}
+
+  const hasTsSource = ['src', 'app', 'pages', 'components', 'lib']
+    .some((folder) => hasFileWithExtensions(resolve(projectRoot, folder), ['.ts', '.tsx', '.mts', '.cts']))
+
+  return hasTsSource ? 'ts' : 'js'
+}

--- a/packages/boneyard/src/registry-file.test.ts
+++ b/packages/boneyard/src/registry-file.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { detectRegistryExtension } from '../bin/registry-file.js'
+
+const createdDirs: string[] = []
+
+function createTempProject() {
+  const dir = mkdtempSync(join(tmpdir(), 'boneyard-registry-'))
+  createdDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (createdDirs.length) {
+    const dir = createdDirs.pop()
+    if (!dir) continue
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('CLI registry filename detection', () => {
+  it('returns ts when tsconfig.json exists', () => {
+    const root = createTempProject()
+    writeFileSync(join(root, 'tsconfig.json'), JSON.stringify({ compilerOptions: {} }))
+
+    expect(detectRegistryExtension(root)).toBe('ts')
+  })
+
+  it('returns js when jsconfig.json exists and tsconfig is absent', () => {
+    const root = createTempProject()
+    writeFileSync(join(root, 'jsconfig.json'), JSON.stringify({ compilerOptions: {} }))
+
+    expect(detectRegistryExtension(root)).toBe('js')
+  })
+
+  it('returns ts when source contains TypeScript files', () => {
+    const root = createTempProject()
+    const srcDir = join(root, 'src')
+    mkdirSync(srcDir, { recursive: true })
+    writeFileSync(join(srcDir, 'index.tsx'), 'export const x = 1')
+
+    expect(detectRegistryExtension(root)).toBe('ts')
+  })
+
+  it('defaults to js for plain projects', () => {
+    const root = createTempProject()
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'plain-js' }))
+
+    expect(detectRegistryExtension(root)).toBe('js')
+  })
+})

--- a/packages/boneyard/src/vite.ts
+++ b/packages/boneyard/src/vite.ts
@@ -19,6 +19,7 @@ import { resolve, join } from 'path'
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs'
 import { createHash } from 'crypto'
 import type { Plugin, ViteDevServer } from 'vite'
+import { detectRegistryExtension } from '../bin/registry-file.js'
 
 export interface BoneyardPluginOptions {
   /** Output directory for .bones.json files (default: './src/bones' or './bones') */
@@ -74,57 +75,6 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       }
     } catch {}
     return 'react'
-  }
-
-  function detectRegistryExtension(root: string): 'ts' | 'js' {
-    if (existsSync(resolve(root, 'tsconfig.json'))) return 'ts'
-    if (existsSync(resolve(root, 'jsconfig.json'))) return 'js'
-    if (existsSync(resolve(root, 'next-env.d.ts'))) return 'ts'
-
-    try {
-      const pkgPath = resolve(root, 'package.json')
-      if (existsSync(pkgPath)) {
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
-        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
-        if (allDeps['typescript']) return 'ts'
-      }
-    } catch {}
-
-    const typeScriptExtensions = new Set(['.ts', '.tsx', '.mts', '.cts'])
-    const candidateDirs = ['src', 'app', 'pages', '.']
-    const visited = new Set<string>()
-
-    const hasTypeScriptSource = (dir: string): boolean => {
-      const fullDir = resolve(root, dir)
-      if (visited.has(fullDir) || !existsSync(fullDir)) return false
-      visited.add(fullDir)
-
-      try {
-        const entries = (require('fs') as typeof import('fs')).readdirSync(fullDir, { withFileTypes: true })
-        for (const entry of entries) {
-          if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist' || entry.name === 'build') {
-            continue
-          }
-
-          const entryPath = join(fullDir, entry.name)
-          if (entry.isDirectory()) {
-            if (hasTypeScriptSource(entryPath)) return true
-            continue
-          }
-
-          for (const ext of typeScriptExtensions) {
-            if (entry.name.endsWith(ext)) return true
-          }
-        }
-      } catch {}
-
-      return false
-    }
-
-    for (const dir of candidateDirs) {
-      if (hasTypeScriptSource(dir)) return 'ts'
-    }
-    return 'js'
   }
 
   const cdpPort = options.cdp

--- a/packages/boneyard/src/vite.ts
+++ b/packages/boneyard/src/vite.ts
@@ -90,6 +90,40 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       }
     } catch {}
 
+    const typeScriptExtensions = new Set(['.ts', '.tsx', '.mts', '.cts'])
+    const candidateDirs = ['src', 'app', 'pages', '.']
+    const visited = new Set<string>()
+
+    const hasTypeScriptSource = (dir: string): boolean => {
+      const fullDir = resolve(root, dir)
+      if (visited.has(fullDir) || !existsSync(fullDir)) return false
+      visited.add(fullDir)
+
+      try {
+        const entries = (require('fs') as typeof import('fs')).readdirSync(fullDir, { withFileTypes: true })
+        for (const entry of entries) {
+          if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist' || entry.name === 'build') {
+            continue
+          }
+
+          const entryPath = join(fullDir, entry.name)
+          if (entry.isDirectory()) {
+            if (hasTypeScriptSource(entryPath)) return true
+            continue
+          }
+
+          for (const ext of typeScriptExtensions) {
+            if (entry.name.endsWith(ext)) return true
+          }
+        }
+      } catch {}
+
+      return false
+    }
+
+    for (const dir of candidateDirs) {
+      if (hasTypeScriptSource(dir)) return 'ts'
+    }
     return 'js'
   }
 

--- a/packages/boneyard/src/vite.ts
+++ b/packages/boneyard/src/vite.ts
@@ -76,6 +76,23 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
     return 'react'
   }
 
+  function detectRegistryExtension(root: string): 'ts' | 'js' {
+    if (existsSync(resolve(root, 'tsconfig.json'))) return 'ts'
+    if (existsSync(resolve(root, 'jsconfig.json'))) return 'js'
+    if (existsSync(resolve(root, 'next-env.d.ts'))) return 'ts'
+
+    try {
+      const pkgPath = resolve(root, 'package.json')
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+        if (allDeps['typescript']) return 'ts'
+      }
+    } catch {}
+
+    return 'js'
+  }
+
   const cdpPort = options.cdp
 
   async function ensureBrowser() {
@@ -103,6 +120,7 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
       const outputDir = detectOutDir(root)
       const fw = detectFramework(root)
+      const registryFilename = `registry.${detectRegistryExtension(root)}`
       const collected: Record<string, any> = {}
 
       const pageUrls = routes.map(route => {
@@ -206,7 +224,7 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       registryLines.push('})')
       registryLines.push('')
 
-      writeFileSync(join(outputDir, 'registry.js'), registryLines.join('\n'))
+      writeFileSync(join(outputDir, registryFilename), registryLines.join('\n'))
 
       const ts = new Date().toLocaleTimeString()
       console.log(`  \x1b[35m[boneyard]\x1b[0m ${ts} — ${names.length} skeleton${names.length !== 1 ? 's' : ''} captured`)


### PR DESCRIPTION
## Commit Description

### Title
`feat(cli): detect ts/js registry filename`

### Summary
This commit adds automatic project language detection so Boneyard generates the correct registry file extension:
- `registry.ts` for TypeScript projects
- `registry.js` for JavaScript projects

The behavior is now applied in both CLI and Vite generation paths, and is covered by dedicated tests.

### Problem
Registry output was previously hardcoded to `registry.js`, which is not ideal for TypeScript-first projects and can create friction in typed codebases.

### Solution
A new detection helper determines project type using stable signals:
1. `tsconfig.json` => TypeScript
2. `jsconfig.json` => JavaScript
3. `next-env.d.ts` => TypeScript
4. `typescript` dependency in package metadata => TypeScript
5. fallback => JavaScript

This detection result is then used to generate:
- `registry.ts` or `registry.js` in CLI output
- `registry.ts` or `registry.js` in Vite plugin output

### Files Changed
- [packages/boneyard/bin/cli.js](packages/boneyard/bin/cli.js)
  - switched registry writes from fixed `registry.js` to dynamic filename based on detection
  - updated output logs to print the actual generated filename
  - applies to normal build, watch updates, and scan mode writes
- [packages/boneyard/src/vite.ts](packages/boneyard/src/vite.ts)
  - added same extension detection flow for plugin-generated registry output
- [packages/boneyard/bin/registry-file.js](packages/boneyard/bin/registry-file.js)
  - new shared helper for registry extension detection used by CLI path
- [packages/boneyard/src/registry-file.test.ts](packages/boneyard/src/registry-file.test.ts)
  - new focused tests to lock extension behavior

### Test Coverage Added
New tests verify:
1. `tsconfig.json` -> `ts`
2. `jsconfig.json` (without `tsconfig.json`) -> `js`
3. TS source presence scenario -> `ts` (for CLI helper behavior)
4. plain/default project fallback -> `js`

### Validation
Executed:
- `npm run test -- src/registry-file.test.ts`

Result:
- `4 passed, 0 failed`

### Backward Compatibility
- Existing extensionless imports like `import './bones/registry'` continue to work.
- No breaking public API changes introduced.
- Change is output-format aware and only affects registry filename selection.

### Impact
This improves DX for contributors and users by aligning generated registry files with the target project language, reducing manual adjustments and preventing accidental JS-only output in TS projects.
