### PR TITLE
release: v1.7.7 (Angular #62 fix)

### DIFF
--- a/apps/docs/src/app/changelog/page.tsx
+++ b/apps/docs/src/app/changelog/page.tsx
@@ -8,12 +8,29 @@ export default function ChangelogPage() {
         </p>
       </div>
 
+      {/* v1.7.7 */}
+      <section>
+        <div className="flex items-center gap-3 mb-4">
+          <span className="text-[14px] font-bold">v1.7.7</span>
+          <span className="text-[12px] text-stone-400">April 2026</span>
+          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Fix Angular skeletons capturing 0 bones</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              The Angular template had two unselected <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">&lt;ng-content&gt;</code> slots (one in the build-mode branch, one in the runtime branch). Angular deduplicates catch-all slots and only projects content into the last declared one — so during CLI capture the build branch rendered as an empty wrapper, producing a 0&nbsp;×&nbsp;0 container and no bones. Collapsed the split into a single template with one catch-all slot, controlling build vs. runtime with <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">*ngIf</code> around the skeleton overlay only. Fixes <a href="https://github.com/0xGF/boneyard/issues/62" className="underline">#62</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* v1.7.6 */}
       <section>
         <div className="flex items-center gap-3 mb-4">
           <span className="text-[14px] font-bold">v1.7.6</span>
           <span className="text-[12px] text-stone-400">April 2026</span>
-          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
         </div>
 
         <div className="space-y-6">

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -34,8 +34,8 @@ export default function RootLayout({
         <BoneRegistryInit />
         {/* Version banner */}
         <a href="/changelog" className="hidden md:flex items-center justify-center gap-1.5 w-full bg-stone-900 py-2 px-4 text-[12px] text-stone-300 hover:text-white transition-colors fixed top-0 left-0 right-0 z-50">
-          <span className="font-medium text-emerald-400">v1.7.6</span>
-          Clean up dark mode detection, fix stale defaults across all frameworks
+          <span className="font-medium text-emerald-400">v1.7.7</span>
+          Fix Angular skeletons capturing 0 bones (ng-content projection bug)
           <span className="text-stone-500">&rarr;</span>
         </a>
         {/* Centered container for sidebar + content */}

--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boneyard-js",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Pixel-perfect skeleton loading screens. Wrap your component in <Skeleton> and boneyard snapshots the real DOM layout — no manual descriptors, no configuration.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/boneyard/src/angular.d.ts
+++ b/packages/boneyard/src/angular.d.ts
@@ -37,7 +37,7 @@ export declare class SkeletonComponent {
     },
     {},
     never,
-    ['*', '[fallback]', '[fixture]'],
+    ['[fixture]', '[fallback]', '*'],
     true,
     never
   >

--- a/packages/boneyard/src/angular.ts
+++ b/packages/boneyard/src/angular.ts
@@ -3,6 +3,7 @@ import {
   Input,
   ElementRef,
   ViewChild,
+  AfterContentInit,
   AfterViewInit,
   OnDestroy,
   OnChanges,
@@ -62,15 +63,20 @@ ensureBuildSnapshotHook()
         data-boneyard-content="true"
         [style.visibility]="!buildMode && showSkeleton && !transitioning ? 'hidden' : null"
       >
+        <!-- Fixture slot: only rendered during CLI capture. -->
         <ng-container *ngIf="buildMode">
           <ng-content select="[fixture]"></ng-content>
         </ng-container>
+        <!-- Fallback slot: rendered while loading if no bones are available. -->
         <ng-container *ngIf="!buildMode && showFallback">
           <ng-content select="[fallback]"></ng-content>
         </ng-container>
-        <ng-container *ngIf="buildMode || !showFallback">
+        <!-- Default slot: real children. Hidden (not removed) in build mode
+             when a fixture is present, or at runtime when the fallback is
+             showing — keeps projection stable across *ngIf changes. -->
+        <div [style.display]="(buildMode && hasFixture) || (!buildMode && showFallback) ? 'none' : null">
           <ng-content></ng-content>
-        </ng-container>
+        </div>
       </div>
 
       <div
@@ -105,7 +111,7 @@ ensureBuildSnapshotHook()
     </div>
   `,
 })
-export class SkeletonComponent implements AfterViewInit, OnDestroy, OnChanges {
+export class SkeletonComponent implements AfterContentInit, AfterViewInit, OnDestroy, OnChanges {
   @Input() loading = false
   @Input() name?: string
   @Input() initialBones?: SkeletonResult | ResponsiveBones
@@ -128,6 +134,8 @@ export class SkeletonComponent implements AfterViewInit, OnDestroy, OnChanges {
   isDark = false
   activeBones: SkeletonResult | null = null
   transitioning = false
+  /** True iff the user projected an element with the [fixture] attribute. */
+  hasFixture = false
 
   get resolvedBoneClass(): string | undefined {
     return this.boneClass ?? _globalConfig.boneClass
@@ -150,7 +158,20 @@ export class SkeletonComponent implements AfterViewInit, OnDestroy, OnChanges {
   private mq: MediaQueryList | null = null
   private mqHandler: (() => void) | null = null
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(
+    private cdr: ChangeDetectorRef,
+    private hostRef: ElementRef<HTMLElement>,
+  ) {}
+
+  ngAfterContentInit(): void {
+    // Detect whether the user projected an element tagged with `fixture`.
+    // Only matters in build mode — at runtime the fixture slot isn't rendered,
+    // so nothing to hide.
+    if (this.buildMode && typeof window !== 'undefined') {
+      this.hasFixture = !!this.hostRef.nativeElement.querySelector('[fixture]')
+      this.cdr.markForCheck()
+    }
+  }
 
   get resolvedColor(): string {
     return this.isDark

--- a/packages/boneyard/src/angular.ts
+++ b/packages/boneyard/src/angular.ts
@@ -51,70 +51,58 @@ ensureBuildSnapshotHook()
   imports: [CommonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <!-- Build mode: render content for CLI capture -->
     <div
-      *ngIf="buildMode; else runtimeMode"
       #container
       [class]="cssClass"
       style="position:relative;"
       [attr.data-boneyard]="name"
       [attr.data-boneyard-config]="serializedSnapshotConfig"
     >
-      <div>
-        <ng-content select="[fixture]"></ng-content>
-        <ng-content></ng-content>
+      <div
+        data-boneyard-content="true"
+        [style.visibility]="!buildMode && showSkeleton && !transitioning ? 'hidden' : null"
+      >
+        <ng-container *ngIf="buildMode">
+          <ng-content select="[fixture]"></ng-content>
+        </ng-container>
+        <ng-container *ngIf="!buildMode && showFallback">
+          <ng-content select="[fallback]"></ng-content>
+        </ng-container>
+        <ng-container *ngIf="buildMode || !showFallback">
+          <ng-content></ng-content>
+        </ng-container>
+      </div>
+
+      <div
+        *ngIf="!buildMode && showSkeleton && activeBones"
+        data-boneyard-overlay="true"
+        [style]="'position:absolute;inset:0;overflow:hidden;opacity:' + (transitioning ? 0 : 1) + ';' + (transitionMs > 0 ? 'transition:opacity ' + transitionMs + 'ms ease-out;' : '')"
+      >
+        <div style="position:relative;width:100%;height:100%;">
+          <div
+            *ngFor="let bone of visibleBones; let i = index; trackBy: trackBone"
+            data-boneyard-bone="true"
+            [class]="resolvedBoneClass"
+            [style]="getBoneStyle(bone, i)"
+          >
+            <div
+              *ngIf="animationStyle !== 'solid'"
+              [style]="getOverlayStyle()"
+            ></div>
+          </div>
+
+          <style *ngIf="animationStyle === 'pulse'">
+            @keyframes bp-{{ uid }} { 0%,100%{opacity:0} 50%{opacity:1} }
+          </style>
+          <style *ngIf="animationStyle === 'shimmer'">
+            @keyframes bs-{{ uid }} { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+          </style>
+          <style *ngIf="staggerMs > 0">
+            @keyframes by-{{ uid }} { from{opacity:0} to{opacity:1} }
+          </style>
+        </div>
       </div>
     </div>
-
-    <!-- Runtime mode -->
-    <ng-template #runtimeMode>
-      <div
-        #container
-        [class]="cssClass"
-        style="position:relative;"
-        [attr.data-boneyard]="name"
-        [attr.data-boneyard-config]="serializedSnapshotConfig"
-      >
-        <div data-boneyard-content="true" [style.visibility]="showSkeleton && !transitioning ? 'hidden' : null">
-          <ng-container *ngIf="showFallback; else defaultContent">
-            <ng-content select="[fallback]"></ng-content>
-          </ng-container>
-          <ng-template #defaultContent>
-            <ng-content></ng-content>
-          </ng-template>
-        </div>
-
-        <div
-          *ngIf="showSkeleton && activeBones"
-          data-boneyard-overlay="true"
-          [style]="'position:absolute;inset:0;overflow:hidden;opacity:' + (transitioning ? 0 : 1) + ';' + (transitionMs > 0 ? 'transition:opacity ' + transitionMs + 'ms ease-out;' : '')"
-        >
-          <div style="position:relative;width:100%;height:100%;">
-            <div
-              *ngFor="let bone of visibleBones; let i = index; trackBy: trackBone"
-              data-boneyard-bone="true"
-              [class]="resolvedBoneClass"
-              [style]="getBoneStyle(bone, i)"
-            >
-              <div
-                *ngIf="animationStyle !== 'solid'"
-                [style]="getOverlayStyle()"
-              ></div>
-            </div>
-
-            <style *ngIf="animationStyle === 'pulse'">
-              @keyframes bp-{{ uid }} { 0%,100%{opacity:0} 50%{opacity:1} }
-            </style>
-            <style *ngIf="animationStyle === 'shimmer'">
-              @keyframes bs-{{ uid }} { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
-            </style>
-            <style *ngIf="staggerMs > 0">
-              @keyframes by-{{ uid }} { from{opacity:0} to{opacity:1} }
-            </style>
-          </div>
-        </div>
-      </div>
-    </ng-template>
   `,
 })
 export class SkeletonComponent implements AfterViewInit, OnDestroy, OnChanges {


### PR DESCRIPTION
## Summary

Ships **v1.7.7** of `boneyard-js`. Contains the Angular skeleton bug fix tracked in #62. PR #60 (TS/JS registry filename detection) already merged to `main` ahead of this, so the tagged release will include both.

### What's in v1.7.7

**`fix(angular)`: project children correctly during CLI capture (#62)** — the Angular `<boneyard-skeleton>` template had two unselected `<ng-content></ng-content>` slots (one in the `*ngIf="buildMode"` branch, one in the `else` runtime branch). Angular only projects content into one such slot, and it wasn't the one rendered during CLI capture — so the container came back as a 0×0 wrapper with `{ height: 0, bones: [] }` at every breakpoint. Collapsed the split into a single template with one catch-all slot, gated only the skeleton overlay on `!buildMode && showSkeleton`. Added `hasFixture` detection via `hostRef.nativeElement.querySelector('[fixture]')` in `ngAfterContentInit` so the docs' fixture+default sibling pattern doesn't stack both elements during capture.

**`feat(cli)`: detect ts/js registry filename (#60, already on `main`)** — CLI and Vite plugin now emit `registry.ts` or `registry.js` based on project signals (tsconfig.json, jsconfig.json, next-env.d.ts, `typescript` dep, TS sources). Shared detection helper consumed by both sides.

Also: bumps `boneyard-js` to 1.7.7, adds a changelog entry linking #62, updates the docs version banner.

## Test plan

- [x] `pnpm --filter boneyard run build` — ngc compiles cleanly, `dist/angular.d.ts` now reports `ngContentSelectors: ["[fixture]", "[fallback]", "*"]` (single catch-all)
- [x] `pnpm --filter boneyard-js run test` — 119 pass (4 pre-existing `runtime.test.ts` failures are unrelated to this PR and present on `main`)
- [x] Ran CLI against docs site — 30 skeletons captured correctly (React regression check)
- [x] Independent audit of the Angular fix — lifecycle timing safe, SSR guarded, no runtime regressions identified
- [ ] Live Angular 21 repro matching #62 — not run (logic review only; confident based on `dist/angular.d.ts` showing the correct single catch-all slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)