### PR TITLE
fix(cli): normalize path separators in route discovery (#65)

### DIFF
--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -682,6 +682,12 @@ function discoverRoutes(origin) {
   const cwd = process.cwd()
   const routes = []
 
+  // Normalize filesystem paths to forward-slash URL paths. On Windows node's
+  // `path.dirname` / `path.join` use `\`, which breaks every downstream regex
+  // and string op in this function (issue #65 — SvelteKit groups never strip,
+  // Next.js nested routes lose their separators, etc.).
+  const toUrlPath = (s) => s.split(/[\\/]+/).join('/')
+
   function walkDir(dir) {
     if (!existsSync(dir)) return []
     const entries = []
@@ -701,10 +707,12 @@ function discoverRoutes(origin) {
   // Next.js App Router: app/**/page.{tsx,jsx,ts,js}
   const appDir = existsSync(join(cwd, 'src/app')) ? join(cwd, 'src/app') : join(cwd, 'app')
   if (existsSync(appDir)) {
+    const appDirUrl = toUrlPath(appDir)
     for (const file of walkDir(appDir)) {
-      const base = file.split('/').pop()
+      const fileUrl = toUrlPath(file)
+      const base = fileUrl.split('/').pop()
       if (/^page\.(tsx|jsx|ts|js)$/.test(base)) {
-        let route = dirname(file).replace(appDir, '') || '/'
+        let route = toUrlPath(dirname(file)).replace(appDirUrl, '') || '/'
         // Skip route groups like (marketing) — flatten them
         route = route.replace(/\/\([^)]+\)/g, '')
         if (!route) route = '/'
@@ -716,13 +724,15 @@ function discoverRoutes(origin) {
   // Next.js Pages Router: pages/**/*.{tsx,jsx,ts,js}
   const pagesDir = existsSync(join(cwd, 'src/pages')) ? join(cwd, 'src/pages') : join(cwd, 'pages')
   if (existsSync(pagesDir) && !existsSync(appDir)) {
+    const pagesDirUrl = toUrlPath(pagesDir)
     for (const file of walkDir(pagesDir)) {
-      const base = file.split('/').pop()
+      const fileUrl = toUrlPath(file)
+      const base = fileUrl.split('/').pop()
       if (!/\.(tsx|jsx|ts|js)$/.test(base)) continue
       // Skip Next.js special files and API routes
       const name = base.replace(/\.(tsx|jsx|ts|js)$/, '')
       if (['_app', '_document', '_error', '404', '500'].includes(name)) continue
-      let route = file.replace(pagesDir, '').replace(/\.(tsx|jsx|ts|js)$/, '')
+      let route = fileUrl.replace(pagesDirUrl, '').replace(/\.(tsx|jsx|ts|js)$/, '')
       if (route.includes('/api/')) continue
       if (route.endsWith('/index')) route = route.replace(/\/index$/, '') || '/'
       routes.push(route)
@@ -732,9 +742,11 @@ function discoverRoutes(origin) {
   // SvelteKit: src/routes/**/+page.svelte
   const svelteDir = join(cwd, 'src/routes')
   if (existsSync(svelteDir)) {
+    const svelteDirUrl = toUrlPath(svelteDir)
     for (const file of walkDir(svelteDir)) {
-      if (file.endsWith('+page.svelte')) {
-        let route = dirname(file).replace(svelteDir, '') || '/'
+      const fileUrl = toUrlPath(file)
+      if (fileUrl.endsWith('+page.svelte')) {
+        let route = toUrlPath(dirname(file)).replace(svelteDirUrl, '') || '/'
         route = route.replace(/\/\([^)]+\)/g, '')
         if (!route) route = '/'
         routes.push(route)
@@ -745,9 +757,11 @@ function discoverRoutes(origin) {
   // Nuxt: pages/**/*.vue
   const nuxtDir = existsSync(join(cwd, 'pages')) ? join(cwd, 'pages') : null
   if (nuxtDir && !existsSync(appDir) && !existsSync(pagesDir)) {
+    const nuxtDirUrl = toUrlPath(nuxtDir)
     for (const file of walkDir(nuxtDir)) {
-      if (!file.endsWith('.vue')) continue
-      let route = file.replace(nuxtDir, '').replace(/\.vue$/, '')
+      const fileUrl = toUrlPath(file)
+      if (!fileUrl.endsWith('.vue')) continue
+      let route = fileUrl.replace(nuxtDirUrl, '').replace(/\.vue$/, '')
       if (route.endsWith('/index')) route = route.replace(/\/index$/, '') || '/'
       routes.push(route)
     }
@@ -756,10 +770,12 @@ function discoverRoutes(origin) {
   // Remix / React Router v7: app/routes/**/*.{tsx,jsx,ts,js}
   const remixDir = join(cwd, 'app/routes')
   if (existsSync(remixDir)) {
+    const remixDirUrl = toUrlPath(remixDir)
     for (const file of walkDir(remixDir)) {
-      const base = file.split('/').pop()
+      const fileUrl = toUrlPath(file)
+      const base = fileUrl.split('/').pop()
       if (!/\.(tsx|jsx|ts|js)$/.test(base)) continue
-      let route = file.replace(remixDir, '').replace(/\.(tsx|jsx|ts|js)$/, '')
+      let route = fileUrl.replace(remixDirUrl, '').replace(/\.(tsx|jsx|ts|js)$/, '')
       // Remix flat routes: dots become slashes, _ prefix = pathless layout
       route = route.replace(/\./g, '/')
       if (route.endsWith('/index') || route.endsWith('/_index')) route = route.replace(/\/_?index$/, '') || '/'


### PR DESCRIPTION
## Summary

- Fixes SvelteKit route discovery on Windows, reported in #65. The filesystem walker at [bin/cli.js:680](packages/boneyard/bin/cli.js#L680) uses \`path.dirname\`/\`path.join\`, which return backslash-separated paths on Windows. Every downstream op — \`replace(svelteDir, '')\`, the group-stripping regex \`/\/\([^)]+\)/g\`, \`split('/')\` — assumed forward slashes. Net effect for the reporter: \`src/routes/(protected)/(app)/(admin_devs)/test_page/+page.svelte\` stayed as \`/(protected)/(app)/(admin_devs)/test_page\` all the way to the URL, and their SvelteKit dev server 404'd.
- Same latent bug existed in the Next.js App Router, Pages Router, Nuxt, and Remix branches — nested routes would have collapsed or kept backslashes on Windows. Unlikely to have been noticed because (a) most reporters of those frameworks are on POSIX, and (b) the CLI falls back to link-crawling when route discovery empties out.

## Fix

- Add a \`toUrlPath()\` helper that normalizes path separators via \`split(/[\\\\/]+/).join('/')\`.
- Apply it to each \`dirName\` and each walked file before regex or string mutation, in all five framework branches.
- POSIX paths are unchanged — no backslashes, no consecutive separators.

## Test plan

- [x] \`pnpm --filter boneyard-js test\` — 119 pass (4 pre-existing \`runtime.test.ts\` failures unrelated)
- [x] Traced the SvelteKit repro manually with Windows-style input: \`C:\\\\project\\\\src\\\\routes\\\\(protected)\\\\(app)\\\\test_page\\\\+page.svelte\` now normalizes to \`/(protected)/(app)/test_page\` pre-regex, strips groups, yields \`/test_page\`.
- [ ] Not run on a real Windows box (no access); the fix is small enough that review should cover it.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)