### PR TITLE
feat(cli): add --version / -v flag (#64)

### DIFF
--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -24,9 +24,23 @@
 
 import { writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync } from 'fs'
 import { resolve, join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 import http from 'http'
 import https from 'https'
 import { detectRegistryExtension } from './registry-file.js'
+
+// Read our own version from the package.json that ships with this CLI.
+// `boneyard-js` may be installed anywhere — walk from this file rather than cwd.
+function getPackageVersion() {
+  try {
+    const selfDir = dirname(fileURLToPath(import.meta.url))
+    const pkgPath = resolve(selfDir, '..', 'package.json')
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+    return pkg.version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
 
 function loadEnvFile(filePath) {
   if (!existsSync(filePath)) {
@@ -59,6 +73,11 @@ function loadEnvFile(filePath) {
 
 const args = process.argv.slice(2)
 const command = args[0]
+
+if (command === '--version' || command === '-v') {
+  console.log(`boneyard-js ${getPackageVersion()}`)
+  process.exit(0)
+}
 
 if (!command || command === '--help' || command === '-h') {
   printHelp()
@@ -1338,6 +1357,7 @@ async function runScan() {
 function printHelp() {
   console.log(`
   boneyard build [url] [options]
+  boneyard --version
 
   Visits your app in a headless browser, captures all named <Skeleton>
   components, and writes .bones.json files + a registry to disk.
@@ -1345,6 +1365,7 @@ function printHelp() {
   Auto-detects your dev server if no URL is given (scans ports 3000, 5173, etc.).
 
   Options:
+    --version, -v        Print boneyard-js version and exit
     --out <dir>          Output directory             (default: ./src/bones)
     --breakpoints <bp>   Comma-separated px widths    (default: 375,768,1280)
     --wait <ms>          Extra wait after page load   (default: 800)


### PR DESCRIPTION
## Summary

Closes #64. Standard CLI convention — \`npm\`, \`node\`, \`pnpm\`, \`playwright\`, etc. all support \`--version\`; \`boneyard-js\` didn't.

Reads the version from boneyard-js's own \`package.json\` (via \`import.meta.url\` so it works no matter where the package is installed), prints \`boneyard-js <version>\`, and exits. Short flag \`-v\` supported too.

## Output

\`\`\`sh
\$ npx boneyard-js --version
boneyard-js 1.7.7

\$ npx boneyard-js -v
boneyard-js 1.7.7
\`\`\`

Also added a line for it in \`--help\`.

## Test plan

- [x] \`node packages/boneyard/bin/cli.js --version\` → \`boneyard-js 1.7.7\`
- [x] \`node packages/boneyard/bin/cli.js -v\` → \`boneyard-js 1.7.7\`
- [x] \`pnpm --filter boneyard-js test\` — 119 pass (no new tests; the flag is straightforward and adding a test that shells out to the CLI for a string match is more ceremony than signal)
- [x] Still exits with the "unknown command" error for other args, and help still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)