### PR TITLE
feat(cli): support explicit routes in boneyard.config.json (#66)

### DIFF
--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -836,6 +836,25 @@ if (skeletonsConfig && typeof skeletonsConfig === 'object' && Object.keys(skelet
       console.log(`  \x1b[2mFound ${added} additional route(s) from filesystem\x1b[0m\n`)
     }
   }
+
+  // Explicit routes from boneyard.config.json — universal escape hatch for
+  // frameworks whose filesystem can't be parsed reliably (Angular lazy modules,
+  // custom routers, server-defined routes, etc.). Supports plain strings
+  // ("/dashboard") or full URLs.
+  if (Array.isArray(config.routes) && config.routes.length > 0) {
+    let added = 0
+    for (const r of config.routes) {
+      if (typeof r !== 'string') continue
+      const url = r.startsWith('http') ? r : `${startOrigin}${r.startsWith('/') ? r : '/' + r}`
+      if (!visited.has(url) && !toVisit.includes(url)) {
+        toVisit.push(url)
+        added++
+      }
+    }
+    if (added > 0) {
+      console.log(`  \x1b[2mAdded ${added} route(s) from boneyard.config.json\x1b[0m\n`)
+    }
+  }
 }
 
 // Visit all discovered pages
@@ -859,7 +878,11 @@ if (Object.keys(collected).length === 0) {
     console.error(
       '\n  boneyard: nothing captured.\n\n' +
       '  Make sure your components have <Skeleton name="my-component" loading={false}>\n' +
-      '  so boneyard can snapshot them before the CLI reads the registry.\n'
+      '  so boneyard can snapshot them before the CLI reads the registry.\n\n' +
+      '  If your skeletons live on routes that aren\'t linked from the start page\n' +
+      '  (common for Angular lazy modules, auth-gated pages, etc.), list them in\n' +
+      '  boneyard.config.json:\n\n' +
+      '    { "routes": ["/dashboard", "/settings/profile"] }\n'
     )
     process.exit(1)
   }
@@ -1365,10 +1388,13 @@ function printHelp() {
     {
       "breakpoints": [375, 768, 1280],
       "out": "./src/bones",
-      "wait": 800
+      "wait": 800,
+      "routes": ["/dashboard", "/settings/profile"]
     }
 
-    CLI flags override config file values.
+    CLI flags override config file values. Use "routes" to explicitly list
+    pages the CLI should visit (useful for Angular lazy modules, auth-gated
+    pages, or any route not linked from the start page).
 
   Authentication (for pages requiring login):
     {

--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -840,12 +840,24 @@ if (skeletonsConfig && typeof skeletonsConfig === 'object' && Object.keys(skelet
   // Explicit routes from boneyard.config.json — universal escape hatch for
   // frameworks whose filesystem can't be parsed reliably (Angular lazy modules,
   // custom routers, server-defined routes, etc.). Supports plain strings
-  // ("/dashboard") or full URLs.
+  // ("/dashboard") or full URLs on the same origin as the crawl target.
   if (Array.isArray(config.routes) && config.routes.length > 0) {
     let added = 0
     for (const r of config.routes) {
-      if (typeof r !== 'string') continue
-      const url = r.startsWith('http') ? r : `${startOrigin}${r.startsWith('/') ? r : '/' + r}`
+      if (typeof r !== 'string' || r.length === 0) continue
+      let url
+      if (/^https?:\/\//i.test(r)) {
+        // Full URL — guard against accidentally crawling an external site.
+        const parsed = (() => { try { return new URL(r) } catch { return null } })()
+        if (!parsed) continue
+        if (parsed.origin !== startOrigin) {
+          console.log(`  \x1b[33m⚠  skipping config.routes entry from a different origin: ${r}\x1b[0m`)
+          continue
+        }
+        url = parsed.toString()
+      } else {
+        url = `${startOrigin}${r.startsWith('/') ? r : '/' + r}`
+      }
       if (!visited.has(url) && !toVisit.includes(url)) {
         toVisit.push(url)
         added++


### PR DESCRIPTION
## Summary

Addresses #66. The reporter has an Angular app where \`/home/some-route\` is only reachable through a \`loadChildren: () => import('./home.routes').then(m => m.homeRoutes)\` declaration — not rendered as a link from \`/\` or \`/home\`, so neither boneyard's link crawler nor its filesystem walker discovers it.

Auto-parsing Angular route trees from \`*.routes.ts\` is a lot to do right: lazy-import resolution, nested \`children:\` arrays, guards, \`redirectTo\`, \`pathMatch\`, etc. A regex-based best-effort would silently misreport. So this PR ships a universal escape hatch instead — \`boneyard.config.json\` now supports a \`routes\` field:

\`\`\`json
{
  \"routes\": [\"/dashboard\", \"/home/some-route\"]
}
\`\`\`

Routes are merged in after filesystem discovery, deduped against the existing \`toVisit\` queue, and crawled normally. Accepts plain paths or full URLs. Works for every framework, not just Angular — the same gap exists for any custom router or page that can't be reached by following \`<a href>\`.

Also:
- Updates the \"nothing captured\" error message to point users at the new option (previously we just said \"make sure you have \`<Skeleton>\`\").
- Adds \`routes\` to the \`--help\` config-file example.

## Why not parse \`*.routes.ts\` automatically?

Happy to do it in a follow-up PR if there's appetite — just didn't want to ship a parser I'd feel nervous about. Even the user's own example needs:
1. Find \`app.routes.ts\`, locate the \`Routes\` export.
2. See \`loadChildren: () => import('./features/home/home.routes').then(m => m.homeRoutes)\`, resolve that relative path, parse \`home.routes.ts\`.
3. Walk the nested \`children:\` array with bracket-matching.
4. Prefix child paths with the parent \`path: 'home'\`.
5. Skip routes with \`redirectTo\` and \`:param\` segments.

Doable without the TS compiler but genuinely fragile. The explicit-routes config gives users a concrete, testable workaround today.

## Test plan

- [x] \`pnpm --filter boneyard-js test\` — 119 pass (4 pre-existing failures unrelated)
- [x] Manual: verified the added block integrates with the existing \`toVisit\` dedup; config-declared URLs get crawled exactly like filesystem-discovered ones
- [x] \`--help\` now shows the \`routes\` key
- [x] Error message for \"nothing captured\" now mentions the option

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)