### PR TITLE
release: v1.7.8 — CLI improvements (#64, #65, #66)

### DIFF
--- a/apps/docs/src/app/changelog/page.tsx
+++ b/apps/docs/src/app/changelog/page.tsx
@@ -8,12 +8,43 @@ export default function ChangelogPage() {
         </p>
       </div>
 
+      {/* v1.7.8 */}
+      <section>
+        <div className="flex items-center gap-3 mb-4">
+          <span className="text-[14px] font-bold">v1.7.8</span>
+          <span className="text-[12px] text-stone-400">April 2026</span>
+          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Add <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">--version</code> flag to the CLI</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">npx boneyard-js --version</code> (or <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">-v</code>) now prints <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">boneyard-js 1.7.8</code>. Reads the version from the shipped <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">package.json</code> via <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">import.meta.url</code> so it works regardless of install location. Fixes <a href="https://github.com/0xGF/boneyard/issues/64" className="underline">#64</a>.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Fix filesystem route discovery on Windows</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">path.dirname</code> and <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">path.join</code> return backslash-separated paths on Windows, so the group-stripping regex in <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">discoverRoutes()</code> never matched. A reporter's SvelteKit route <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">(protected)/(app)/(admin_devs)/test_page</code> was being crawled with the groups intact, 404'ing their dev server. Added a <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">toUrlPath()</code> helper that normalizes separators before any regex or string op; applied to all 5 framework branches. Fixes <a href="https://github.com/0xGF/boneyard/issues/65" className="underline">#65</a>.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Support explicit routes in <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">boneyard.config.json</code></h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              Some pages can't be reached by link-crawling or filesystem walking — Angular <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">loadChildren</code> lazy modules, auth-gated pages, custom routers. Added a <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">routes</code> field to the config that accepts plain paths (<code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">&quot;/dashboard&quot;</code>) or same-origin full URLs. They're merged in after filesystem discovery and crawled normally. Also updated the &quot;nothing captured&quot; error to point users at this option. Addresses <a href="https://github.com/0xGF/boneyard/issues/66" className="underline">#66</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* v1.7.7 */}
       <section>
         <div className="flex items-center gap-3 mb-4">
           <span className="text-[14px] font-bold">v1.7.7</span>
           <span className="text-[12px] text-stone-400">April 2026</span>
-          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
         </div>
 
         <div className="space-y-6">

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -34,8 +34,8 @@ export default function RootLayout({
         <BoneRegistryInit />
         {/* Version banner */}
         <a href="/changelog" className="hidden md:flex items-center justify-center gap-1.5 w-full bg-stone-900 py-2 px-4 text-[12px] text-stone-300 hover:text-white transition-colors fixed top-0 left-0 right-0 z-50">
-          <span className="font-medium text-emerald-400">v1.7.7</span>
-          Fix Angular skeletons capturing 0 bones (ng-content projection bug)
+          <span className="font-medium text-emerald-400">v1.7.8</span>
+          CLI: --version flag, Windows route-path fix, explicit routes config
           <span className="text-stone-500">&rarr;</span>
         </a>
         {/* Centered container for sidebar + content */}

--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boneyard-js",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Pixel-perfect skeleton loading screens. Wrap your component in <Skeleton> and boneyard snapshots the real DOM layout — no manual descriptors, no configuration.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump, changelog entry, and docs banner update for **v1.7.8**. All three feature/fix PRs already landed on \`main\` via separate PRs — this is the release bookkeeping.

### Shipped in v1.7.8

- **[feat(cli): --version / -v flag](https://github.com/0xGF/boneyard/pull/68)** ([#64](https://github.com/0xGF/boneyard/issues/64)) — \`npx boneyard-js --version\` → \`boneyard-js 1.7.8\`. Reads from the CLI's own package.json via \`import.meta.url\`.
- **[fix(cli): Windows path separators in route discovery](https://github.com/0xGF/boneyard/pull/67)** ([#65](https://github.com/0xGF/boneyard/issues/65)) — \`path.dirname\`/\`path.join\` return backslashes on Windows, breaking the group-stripping regex across all 5 framework branches. SvelteKit route groups like \`(protected)/(app)/test_page\` were never stripped, and the CLI was crawling \`/(protected)/(app)/test_page\` against dev servers that 404'd it. Added a \`toUrlPath()\` normalizer.
- **[feat(cli): explicit routes in boneyard.config.json](https://github.com/0xGF/boneyard/pull/69)** ([#66](https://github.com/0xGF/boneyard/issues/66)) — universal escape hatch for frameworks with lazy-loaded / auth-gated routes that can't be reached by link crawling. Users list routes explicitly; accepts plain paths or same-origin full URLs.

## Test plan

- [x] \`pnpm --filter boneyard run build\` — clean
- [x] \`pnpm --filter boneyard-js test\` — 119 pass (4 pre-existing \`runtime.test.ts\` failures unrelated)
- [x] \`node packages/boneyard/bin/cli.js --version\` → \`boneyard-js 1.7.8\`
- [x] Docs banner renders \`v1.7.8\` + changelog page shows the new section at the top
- [x] Audit pass done — one tightening (proper URL parsing + origin guard in PR #69) applied pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)