### PR TITLE
fix(cli): reuse existing browser context when connecting via --cdp

### DIFF
--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -394,7 +394,10 @@ let cdpContext = null
 if (cdpPort) {
   try {
     browser = await chromium.connectOverCDP(`http://localhost:${cdpPort}`)
-    cdpContext = await browser.newContext()
+    // Reuse the existing browser context so cookies and auth state from
+    // the user's Chrome session carry over. `--cdp` documents this as
+    // "reuses cookies, auth, state" — a fresh context breaks that promise.
+    cdpContext = browser.contexts()[0] ?? await browser.newContext()
     console.log(`  \x1b[2mConnected to Chrome on port ${cdpPort}\x1b[0m\n`)
   } catch (e) {
     console.error(


### PR DESCRIPTION
## Summary

`--cdp` is documented in the CLI help as:

> Connect to existing Chrome via debug port instead of launching Playwright (**reuses cookies, auth, state**).

But today it doesn't. After `chromium.connectOverCDP()`, the CLI calls `browser.newContext()`, which creates a fresh context that doesn't inherit cookies or storage from the user's Chrome session. The promise in the help text is broken for every authed route.

This PR reuses the existing default context when one is available, falling back to `newContext()` only when Chrome has no contexts yet (e.g. just-launched with no open window).

```js
// before
cdpContext = await browser.newContext()

// after
cdpContext = browser.contexts()[0] ?? await browser.newContext()
```

## Why this matters

Running `npx boneyard-js build --cdp 9222` against any app with auth (Clerk, NextAuth, your own cookie session, …) currently returns `No skeletons found` because every page redirects to sign-in. With this fix the attached tab inherits the existing session and skeletons behind auth are captured.

## Test plan

- [x] Reproduced the original bug: started Chrome with `--remote-debugging-port=9222`, signed into a Clerk-gated app, ran `npx boneyard-js build http://localhost:5173/authed-route --cdp 9222 --no-scan`. Result: every route redirected to `/sign-in`, nothing captured.
- [x] Applied the fix, re-ran the same command. Result: `✓ agent-overview-section  5 bones` — skeleton captured from the authed page.
- [x] `pnpm --filter boneyard-js run test` — 119 pass, 4 fail (same 4 pre-existing failures on `main`, unrelated to this change).

No test added because verifying this end-to-end needs a real Chrome with `--remote-debugging-port`; happy to add one if the repo grows a fixture for that.