### PR TITLE
fix(vite): surface silent-stuck capture; honour config auth; reuse CDP context (#75)

### DIFF
--- a/packages/boneyard/src/vite.ts
+++ b/packages/boneyard/src/vite.ts
@@ -17,7 +17,6 @@
 
 import { resolve, join } from 'path'
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs'
-import { createHash } from 'crypto'
 import type { Plugin, ViteDevServer } from 'vite'
 import { detectRegistryExtension } from '../bin/registry-file.js'
 
@@ -32,19 +31,67 @@ export interface BoneyardPluginOptions {
   framework?: 'react' | 'vue' | 'svelte' | 'preact'
   /** Skip initial capture on server start (default: false) */
   skipInitial?: boolean
-  /** Connect to existing Chrome via debug port instead of launching Playwright */
+  /** Connect to existing Chrome via debug port instead of launching Playwright (reuses cookies, auth, state) */
   cdp?: number
   /** Routes to capture skeletons from (default: ['/']). The plugin visits each route at every breakpoint. */
   routes?: string[]
+  /** Verbose per-step logging — useful when capture returns nothing and you need to see why */
+  debug?: boolean
+}
+
+type BoneyardConfig = {
+  routes?: string[]
+  breakpoints?: number[]
+  wait?: number
+  out?: string
+  auth?: {
+    cookies?: Array<{ name: string; value: string; domain?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: 'Strict' | 'Lax' | 'None' }>
+    headers?: Record<string, string>
+  }
+}
+
+const ALLOWED_COOKIE_KEYS = new Set(['name', 'value', 'path', 'domain', 'expires', 'httpOnly', 'secure', 'sameSite'])
+const BLOCKED_HEADERS = new Set(['host', 'content-length', 'transfer-encoding', 'connection', 'upgrade'])
+
+function loadConfig(root: string): BoneyardConfig | null {
+  const p = resolve(root, 'boneyard.config.json')
+  if (!existsSync(p)) return null
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8')) as BoneyardConfig
+  } catch (e: any) {
+    console.log(`  \x1b[35m[boneyard]\x1b[0m failed to parse boneyard.config.json — ${e.message}`)
+    return null
+  }
+}
+
+function sanitizeCookies(cookies: NonNullable<BoneyardConfig['auth']>['cookies']): any[] {
+  if (!cookies) return []
+  return cookies.map(c => {
+    const safe: Record<string, any> = {}
+    for (const [k, v] of Object.entries(c)) {
+      if (ALLOWED_COOKIE_KEYS.has(k)) safe[k] = v
+    }
+    return safe
+  })
+}
+
+function sanitizeHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+  if (!headers) return {}
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) {
+    if (BLOCKED_HEADERS.has(k.toLowerCase())) {
+      console.log(`  \x1b[35m[boneyard]\x1b[0m blocked unsafe header '${k}' in auth config`)
+      continue
+    }
+    out[k] = v
+  }
+  return out
 }
 
 export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
-  const {
-    breakpoints = [375, 768, 1280],
-    wait = 800,
-    skipInitial = false,
-    routes = ['/'],
-  } = options
+  const debug = options.debug === true
+  const log = (msg: string) => console.log(`  \x1b[35m[boneyard]\x1b[0m ${msg}`)
+  const dbg = (msg: string) => { if (debug) log(msg) }
 
   let outDir = options.out ?? ''
   let detectedFramework = options.framework ?? ''
@@ -55,6 +102,14 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
   let page: any = null
   let initialCaptureDone = false
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let loadedConfig: BoneyardConfig | null = null
+
+  // Options may be overridden by boneyard.config.json — resolved in configureServer.
+  let breakpoints = options.breakpoints ?? [375, 768, 1280]
+  let wait = options.wait ?? 800
+  let routes = options.routes ?? ['/']
+  const skipInitial = options.skipInitial === true
+  const cdpPort = options.cdp
 
   function detectOutDir(root: string): string {
     if (outDir) return resolve(root, outDir)
@@ -77,19 +132,44 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
     return 'react'
   }
 
-  const cdpPort = options.cdp
-
   async function ensureBrowser() {
     if (browser && page) return
     const pw = await import('playwright')
+    let context: any
     if (cdpPort) {
+      dbg(`connecting to Chrome on port ${cdpPort}`)
       browser = await pw.chromium.connectOverCDP(`http://localhost:${cdpPort}`)
-      const context = await browser.newContext()
-      page = await context.newPage()
+      // Reuse the existing browser context so cookies and auth state from
+      // the user's Chrome session carry over (matches the CLI's --cdp fix
+      // in #73). A fresh context would throw away any logged-in session.
+      context = browser.contexts()[0] ?? await browser.newContext()
     } else {
+      dbg('launching headless chromium')
       browser = await pw.chromium.launch()
-      page = await browser.newPage()
+      context = await browser.newContext()
     }
+    page = await context.newPage()
+
+    // Apply auth from boneyard.config.json, if any.
+    const auth = loadedConfig?.auth
+    if (auth?.cookies?.length) {
+      const cookies = sanitizeCookies(auth.cookies)
+      log(`applying ${cookies.length} cookie(s) from boneyard.config.json`)
+      try {
+        await context.addCookies(cookies)
+      } catch (e: any) {
+        log(`failed to apply cookies — ${e.message}`)
+      }
+    }
+    if (auth?.headers && Object.keys(auth.headers).length) {
+      const headers = sanitizeHeaders(auth.headers)
+      const count = Object.keys(headers).length
+      if (count) {
+        log(`applying ${count} header(s) from boneyard.config.json`)
+        await page.setExtraHTTPHeaders(headers)
+      }
+    }
+
     await page.addInitScript(() => {
       (window as any).__BONEYARD_BUILD = true
     })
@@ -106,6 +186,7 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       const fw = detectFramework(root)
       const registryFilename = `registry.${detectRegistryExtension(root)}`
       const collected: Record<string, any> = {}
+      const routeDiagnostics: Array<{ path: string; finalPath: string; redirected: boolean; markerCount: number; title: string; error?: string }> = []
 
       const pageUrls = routes.map(route => {
         const r = route.startsWith('/') ? route : `/${route}`
@@ -113,20 +194,64 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       })
 
       for (const pageUrl of pageUrls) {
+        const requestedPath = new URL(pageUrl).pathname
+        const diag: typeof routeDiagnostics[number] = {
+          path: requestedPath,
+          finalPath: requestedPath,
+          redirected: false,
+          markerCount: 0,
+          title: '',
+        }
+
         for (const width of breakpoints) {
           await page.setViewportSize({ width, height: 900 })
 
           try {
             await page.goto(pageUrl, { waitUntil: 'networkidle', timeout: 15_000 })
-          } catch {
-            // networkidle can timeout — still try
+          } catch (e: any) {
+            // networkidle can legitimately time out on long-polling pages,
+            // but other errors (DNS, connection refused, invalid URL) are
+            // usually fatal for this route. Record either way so the user
+            // has something to look at when nothing is captured.
+            const isTimeout = e?.name === 'TimeoutError' || /timeout/i.test(e?.message ?? '')
+            if (!isTimeout) {
+              diag.error = e?.message ?? String(e)
+            } else {
+              dbg(`${requestedPath} @ ${width}px — networkidle timeout (proceeding anyway)`)
+            }
+          }
+
+          // Detect auth redirects etc. Once is enough — only log on first breakpoint.
+          if (width === breakpoints[0]) {
+            const finalUrl = page.url()
+            try {
+              const finalPath = new URL(finalUrl).pathname
+              diag.finalPath = finalPath
+              diag.redirected = finalPath !== requestedPath
+              if (diag.redirected) {
+                log(`\x1b[33m⚠  Redirected: ${requestedPath} → ${finalPath}\x1b[0m`)
+              }
+            } catch {}
           }
 
           if (wait > 0) await page.waitForTimeout(wait)
 
+          // Capture page-level diagnostics once per route (cheapest breakpoint).
+          if (width === breakpoints[0]) {
+            try {
+              const info = await page.evaluate(() => ({
+                title: document.title ?? '',
+                markerCount: document.querySelectorAll('[data-boneyard]').length,
+              }))
+              diag.title = info.title
+              diag.markerCount = info.markerCount
+              dbg(`${requestedPath} — title="${info.title}", ${info.markerCount} <Skeleton> marker(s)`)
+            } catch {}
+          }
+
           const bones = await page.evaluate(() => {
             const fn = (window as any).__BONEYARD_SNAPSHOT
-            if (!fn) return {}
+            if (!fn) return { __error: 'no-snapshot-fn' as const }
 
             const elements = document.querySelectorAll('[data-boneyard]')
             const results: Record<string, any> = {}
@@ -142,34 +267,70 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
               try {
                 results[name] = fn(target, name, config)
-              } catch {}
+              } catch (err: any) {
+                results[name] = { __error: err?.message ?? String(err) }
+              }
             }
 
             return results
           })
 
-          for (const [name, result] of Object.entries(bones)) {
+          if (bones && typeof bones === 'object' && '__error' in (bones as any)) {
+            // No __BONEYARD_SNAPSHOT on the page — the <Skeleton> component
+            // didn't mount. Most likely the user is capturing a route that
+            // doesn't render a <Skeleton>, or the registry import isn't
+            // being loaded by the app entry.
+            if (width === breakpoints[0]) {
+              log(`\x1b[33m⚠  ${requestedPath} — __BONEYARD_SNAPSHOT not on window; <Skeleton> may not have mounted\x1b[0m`)
+            }
+            continue
+          }
+
+          for (const [name, result] of Object.entries(bones as Record<string, any>)) {
             if (!result) continue
+            if (result.__error) {
+              log(`\x1b[33m⚠  ${requestedPath} — ${name}: snapshot threw: ${result.__error}\x1b[0m`)
+              continue
+            }
             const safeName = name.replace(/[^a-zA-Z0-9_-]/g, '_')
             if (!collected[safeName]) collected[safeName] = { breakpoints: {} }
 
             // Compact bones
-            const r = result as any
-            if (r.bones) {
-              r.bones = r.bones.map((b: any) => {
+            if (result.bones) {
+              result.bones = result.bones.map((b: any) => {
                 const arr = [b.x, b.y, b.w, b.h, b.r]
                 if (b.c) arr.push(true)
                 return arr
               })
             }
-            collected[safeName].breakpoints[width] = r
+            collected[safeName].breakpoints[width] = result
           }
         }
+
+        routeDiagnostics.push(diag)
       }
 
       // Check if anything changed
       const snapshot = JSON.stringify(collected)
-      if (snapshot === lastSnapshot || Object.keys(collected).length === 0) {
+      if (Object.keys(collected).length === 0) {
+        // Nothing captured. Always print the per-route rundown so the user
+        // can see why — this is the failure mode #75 flagged.
+        log('captured 0 skeletons — nothing to write')
+        for (const d of routeDiagnostics) {
+          const bits = [`  ${d.path}`]
+          if (d.redirected) bits.push(`→ ${d.finalPath}`)
+          if (d.error) bits.push(`[error: ${d.error}]`)
+          if (d.title) bits.push(`title="${d.title}"`)
+          bits.push(`${d.markerCount} marker(s)`)
+          log(bits.join(' '))
+        }
+        if (routeDiagnostics.every(d => d.markerCount === 0)) {
+          log('no <Skeleton> markers anywhere — is the registry import wired up? did the pages redirect to a login screen?')
+        }
+        return
+      }
+      if (snapshot === lastSnapshot) {
+        dbg('snapshot unchanged — no files rewritten')
         return
       }
       lastSnapshot = snapshot
@@ -211,12 +372,16 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       writeFileSync(join(outputDir, registryFilename), registryLines.join('\n'))
 
       const ts = new Date().toLocaleTimeString()
-      console.log(`  \x1b[35m[boneyard]\x1b[0m ${ts} — ${names.length} skeleton${names.length !== 1 ? 's' : ''} captured`)
+      log(`${ts} — ${names.length} skeleton${names.length !== 1 ? 's' : ''} captured`)
 
     } catch (err: any) {
-      // Silently handle errors — server might be restarting
-      if (err.message && !err.message.includes('Target closed')) {
-        console.log(`  \x1b[35m[boneyard]\x1b[0m error: ${err.message}`)
+      // "Target closed" happens legitimately when the dev server restarts
+      // or the browser was torn down mid-capture — not worth alerting on.
+      if (err?.message?.includes('Target closed')) {
+        dbg(`capture aborted — ${err.message}`)
+      } else {
+        log(`\x1b[31m✗  capture failed: ${err?.message ?? err}\x1b[0m`)
+        if (debug && err?.stack) console.log(err.stack)
       }
     } finally {
       capturing = false
@@ -229,6 +394,25 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
     configureServer(srv) {
       server = srv
+
+      // Load boneyard.config.json once at startup. Plugin options still win
+      // when both are set, so config is treated as a fallback.
+      loadedConfig = loadConfig(srv.config.root)
+      if (loadedConfig) {
+        dbg('loaded boneyard.config.json')
+        if (options.breakpoints === undefined && Array.isArray(loadedConfig.breakpoints)) {
+          breakpoints = loadedConfig.breakpoints
+        }
+        if (options.wait === undefined && typeof loadedConfig.wait === 'number') {
+          wait = loadedConfig.wait
+        }
+        if (options.out === undefined && typeof loadedConfig.out === 'string') {
+          outDir = loadedConfig.out
+        }
+        if (options.routes === undefined && Array.isArray(loadedConfig.routes) && loadedConfig.routes.length) {
+          routes = loadedConfig.routes
+        }
+      }
 
       // Clean up browser when dev server closes
       srv.httpServer?.on('close', async () => {
@@ -247,7 +431,8 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
           // Delay initial capture to let the server fully start
           setTimeout(async () => {
-            console.log(`  \x1b[35m[boneyard]\x1b[0m watching for skeleton changes...`)
+            log(`watching for skeleton changes...`)
+            dbg(`routes: ${routes.join(', ')}  breakpoints: ${breakpoints.join(', ')}px`)
             await capture(url, srv.config.root)
             initialCaptureDone = true
           }, 2000)


### PR DESCRIPTION
Addresses [#75](https://github.com/0xGF/boneyard/issues/75) — the \"stuck on \`watching for skeleton changes...\` with no further output\" failure mode.

## The root cause

Three places in [packages/boneyard/src/vite.ts](https://github.com/0xGF/boneyard/blob/v1.7.9/packages/boneyard/src/vite.ts) ate errors silently:

1. \`page.goto()\` failures were fully swallowed (redirects, timeouts, connection refused, invalid URLs — all invisible).
2. When \`collected\` ended up empty — which happens on every run where auth bounces the headless browser to /login — the plugin just \`return\`ed without a word.
3. The outer \`try/catch\` only logged errors that didn't contain \"Target closed\", dropping everything else.

Plus two things that made the auth case specifically worse:

- The plugin never read \`auth\` from \`boneyard.config.json\` — that's a CLI-only feature. Users setting \`auth.cookies\` saw nothing apply.
- The plugin's \`cdp:\` option had the same context-reuse bug we just fixed in the CLI in #73: it called \`browser.newContext()\` after \`connectOverCDP\`, throwing away the Chrome session the user was trying to inherit.

## What this PR does

### Diagnostics on empty capture

When a capture pass ends with zero skeletons, the plugin now prints the per-route rundown it had all along but was hiding:

\`\`\`
[boneyard] captured 0 skeletons — nothing to write
[boneyard]   /dashboard → /sign-in title=\"Sign in\" 0 marker(s)
[boneyard]   /settings  → /sign-in title=\"Sign in\" 0 marker(s)
[boneyard] no <Skeleton> markers anywhere — is the registry import wired up? did the pages redirect to a login screen?
\`\`\`

Redirects are also logged at the first breakpoint as they happen (matching the CLI's \`⚠ Redirected: /foo → /bar\` output).

### page.goto / snapshot failures bubble up

- \`page.goto\` errors that aren't \`networkidle\` timeouts are recorded on the route diagnostic and shown in the empty-capture rundown.
- \`__BONEYARD_SNAPSHOT\` missing on a page is now a visible warning (\`<Skeleton> may not have mounted\`) instead of silent.
- Per-skeleton snapshot throws propagate as warnings with the skeleton name and the error message.
- The outer catch now logs all real failures; only the benign \"Target closed\" (dev-server restart / browser teardown) stays quiet. Stack traces included when \`debug\` is on.

### Honour \`boneyard.config.json\` in the plugin

The plugin now loads \`boneyard.config.json\` from the Vite project root and reads:

- \`routes\`, \`breakpoints\`, \`wait\`, \`out\` as fallbacks (plugin options still win)
- \`auth.cookies\` — sanitized against the same allowlist the CLI uses (\`name\`, \`value\`, \`path\`, \`domain\`, \`expires\`, \`httpOnly\`, \`secure\`, \`sameSite\`) and applied via \`context.addCookies\`
- \`auth.headers\` — sanitized against the same blocklist the CLI uses (\`host\`, \`content-length\`, \`transfer-encoding\`, \`connection\`, \`upgrade\`) and applied via \`page.setExtraHTTPHeaders\`

### \`cdp:\` reuses existing context (port of #73)

\`\`\`ts
// before
const context = await browser.newContext()

// after
context = browser.contexts()[0] ?? await browser.newContext()
\`\`\`

Same reasoning as [#73](https://github.com/0xGF/boneyard/pull/73) — the point of \`cdp:\` is to inherit session state; \`newContext()\` discards it.

### New \`debug: true\` option

\`\`\`ts
boneyardPlugin({ debug: true })
\`\`\`

Verbose per-step output: config loaded, browser launch/connect, each route's title and marker count at every pass, \`networkidle\` timeouts, snapshot-unchanged early returns, \"Target closed\" early aborts. The non-debug output stays close to what it is today — quiet on the happy path, loud on failure.

## Test plan

- [x] \`pnpm --filter boneyard-js run build\` — clean.
- [x] \`pnpm --filter boneyard-js run test\` — 123 pass / 0 fail.
- [ ] **@gedkirkham — can you try this branch against your Quasar/Vite app and share what the output looks like?** Install from the branch with:

  \`\`\`bash
  # from your project root
  pnpm add -D 'github:0xGF/boneyard#fix/vite-plugin-debug-auth-cdp&path:/packages/boneyard'
  \`\`\`

  Or clone + pnpm link if that's easier. Then either:
  - turn on \`boneyardPlugin({ debug: true })\` in your \`vite.config\` and run dev, **or**
  - just run dev as you are today — the empty-capture rundown is always on now.

  The per-route marker counts and redirect warnings should make it obvious whether the issue is (a) auth redirecting every page to login, (b) registry not imported on the app entry, or (c) something else we haven't thought of. Happy to iterate on the logging based on what you see.

## Not in scope

- No tests for the plugin itself — it's all I/O (playwright + fs) and the existing suite has no plugin harness. Open to adding one if a pattern would be useful, but kept out of this PR to keep the diff focused on the user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)