### PR TITLE
release: v1.8.0 — Vite plugin diagnostics + auth, single-page CLI capture

### DIFF
--- a/apps/docs/src/app/changelog/page.tsx
+++ b/apps/docs/src/app/changelog/page.tsx
@@ -8,12 +8,50 @@ export default function ChangelogPage() {
         </p>
       </div>
 
+      {/* v1.8.0 */}
+      <section>
+        <div className="flex items-center gap-3 mb-4">
+          <span className="text-[14px] font-bold">v1.8.0</span>
+          <span className="text-[12px] text-stone-400">April 2026</span>
+          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Vite plugin no longer fails silently</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              Three places in the Vite plugin used to swallow errors silently — <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">page.goto</code> failures, empty captures, and most exceptions in the outer catch — leaving users staring at <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">[boneyard] watching for skeleton changes...</code> with no way to diagnose. The plugin now prints a per-route rundown when capture returns nothing (final path so redirects are visible, page title, <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">data-boneyard</code> marker count, any <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">page.goto</code> error). Redirects log at the first breakpoint as they happen. The outer catch logs all real failures; only the benign &quot;Target closed&quot; (dev-server restart) stays quiet. New <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">debug: true</code> plugin option turns on verbose per-step logging. Fixes <a href="https://github.com/0xGF/boneyard/issues/75" className="underline">#75</a> via <a href="https://github.com/0xGF/boneyard/pull/77" className="underline">#77</a>.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Vite plugin reads <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">boneyard.config.json</code> (incl. <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">auth</code>)</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">routes</code>, <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">breakpoints</code>, <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">wait</code>, <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">out</code>, and <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">auth</code> (cookies + headers, sanitized against the same allowlist/blocklist the CLI uses) are now honoured by the plugin as fallbacks. Plugin options still win when both are set. Authed pages behind cookie sessions can be captured in watch mode without a second terminal.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1">Vite plugin <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">cdp</code> reuses your Chrome session</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              Same fix as <a href="https://github.com/0xGF/boneyard/pull/73" className="underline">#73</a> in the CLI, ported to the plugin. <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">browser.contexts()[0] ?? browser.newContext()</code> — inherits cookies/auth from the Chrome window you point it at instead of spawning a fresh empty context.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1"><code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">npx boneyard-js build {'<url>'}/path</code> now actually captures only that page</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              The CLI documents <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">npx boneyard-js build http://localhost:3000/dashboard</code> as the way to capture a &quot;Specific page&quot;, but the implementation treated every URL as a starting point — link-following from the page, walking <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">app/**/page.tsx</code> for additional routes, adding anything in <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">config.routes</code>. So passing <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">/dashboard/analytics</code> still scanned the whole project. Now: when any URL has a non-root path, the CLI prints <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">Specific page: 1 URL(s) — no link/filesystem crawl</code> and visits exactly the URL(s) you passed. Bare-origin URLs (<code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">http://localhost:3000</code>) and the auto-detect path keep crawling everything. Fixes <a href="https://github.com/0xGF/boneyard/issues/78" className="underline">#78</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* v1.7.9 */}
       <section>
         <div className="flex items-center gap-3 mb-4">
           <span className="text-[14px] font-bold">v1.7.9</span>
           <span className="text-[12px] text-stone-400">April 2026</span>
-          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
         </div>
 
         <div className="space-y-6">

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -34,8 +34,8 @@ export default function RootLayout({
         <BoneRegistryInit />
         {/* Version banner */}
         <a href="/changelog" className="hidden md:flex items-center justify-center gap-1.5 w-full bg-stone-900 py-2 px-4 text-[12px] text-stone-300 hover:text-white transition-colors fixed top-0 left-0 right-0 z-50">
-          <span className="font-medium text-emerald-400">v1.7.9</span>
-          Typed JSON bone imports, --cdp reuses Chrome session, test suite green
+          <span className="font-medium text-emerald-400">v1.8.0</span>
+          Vite plugin diagnostics + config auth, single-page CLI capture, --cdp parity
           <span className="text-stone-500">&rarr;</span>
         </a>
         {/* Centered container for sidebar + content */}

--- a/apps/docs/src/app/overview/page.tsx
+++ b/apps/docs/src/app/overview/page.tsx
@@ -51,7 +51,7 @@ function DashboardMock() {
         </div>
       </article>
       <div className="flex flex-col gap-1">
-        {["v1.7.9 — 7 bones captured", "v1.7.8 — 12 routes scanned"].map((row, i) => (
+        {["v1.8.0 — 7 bones captured", "v1.7.9 — 12 routes scanned"].map((row, i) => (
           <article key={i} className="h-5 bg-stone-50 border border-stone-100 rounded flex items-center px-2 text-[9px] text-stone-500 truncate">{row}</article>
         ))}
       </div>

--- a/apps/docs/src/components/sidebar.tsx
+++ b/apps/docs/src/components/sidebar.tsx
@@ -107,7 +107,7 @@ export function Sidebar() {
       {/* Footer */}
       <div className="py-4 space-y-1.5">
         <div className="flex items-center gap-2">
-          <span className="text-[12px] text-[#a8a29e]">v1.7.9</span>
+          <span className="text-[12px] text-[#a8a29e]">v1.8.0</span>
           <a
             href="https://github.com/0xGF/boneyard"
             target="_blank"

--- a/packages/boneyard/bin/cli.js
+++ b/packages/boneyard/bin/cli.js
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'url'
 import http from 'http'
 import https from 'https'
 import { detectRegistryExtension } from './registry-file.js'
+import { isSinglePageMode } from './url-helpers.js'
 
 // Read our own version from the package.json that ships with this CLI.
 // `boneyard-js` may be installed anywhere — walk from this file rather than cwd.
@@ -827,9 +828,22 @@ function discoverRoutes(origin) {
 const startUrl = urls[0]
 const startOrigin = new URL(startUrl).origin
 
+// Single-page mode: when the user explicitly passed at least one URL with
+// a non-root path (e.g. `npx boneyard-js build http://localhost:3000/dashboard`)
+// the docs promise "Specific page" capture (apps/docs/src/app/cli/page.tsx).
+// Honour that promise — skip link-following, skip filesystem route discovery,
+// skip config.routes/skeletons augmentation. The given URLs ARE the queue.
+// Bare-origin URLs and the auto-detect path keep the legacy crawl behaviour.
+const singlePageMode = isSinglePageMode(urls)
+
 // Per-skeleton guided crawling: skip route discovery and go directly to specified routes
 const skeletonsConfig = config.skeletons
-if (skeletonsConfig && typeof skeletonsConfig === 'object' && Object.keys(skeletonsConfig).length > 0) {
+if (singlePageMode) {
+  const label = urls.length === 1 ? 'page' : 'pages'
+  console.log(`  \x1b[2mSpecific ${label}: ${urls.length} URL(s) — no link/filesystem crawl\x1b[0m\n`)
+  // toVisit was initialized with [...urls] above — that's already the full
+  // queue. Nothing else to add.
+} else if (skeletonsConfig && typeof skeletonsConfig === 'object' && Object.keys(skeletonsConfig).length > 0) {
   const entries = Object.entries(skeletonsConfig)
   console.log(`  \x1b[2mGuided crawl: ${entries.length} skeleton(s) configured\x1b[0m\n`)
   const guidedRoutes = new Set()
@@ -1127,6 +1141,9 @@ if (watchMode && !nativeMode) {
       for (const watchUrl of [...toVisit]) {
         if (visited.has(watchUrl)) continue
         visited.add(watchUrl)
+        // In single-page mode the explicit URLs are the entire queue —
+        // do not follow links out of them.
+        if (singlePageMode) continue
         const links = await discoverLinks(watchUrl)
         for (const link of links) {
           if (!visited.has(link) && !toVisit.includes(link)) toVisit.push(link)

--- a/packages/boneyard/bin/url-helpers.js
+++ b/packages/boneyard/bin/url-helpers.js
@@ -1,0 +1,50 @@
+/**
+ * URL classification helpers for the CLI.
+ *
+ * Kept in its own module (rather than inline in cli.js) so the logic can be
+ * unit-tested from `src/` without spawning a real CLI subprocess. Imported by
+ * `bin/cli.js` and `src/cli-url.test.ts`.
+ */
+
+/**
+ * Returns true when the URL has a non-root path — anything after the origin
+ * other than `/` or empty. Examples:
+ *
+ *   http://localhost:3000              → false  (bare origin)
+ *   http://localhost:3000/             → false  (root path)
+ *   http://localhost:3000/dashboard    → true
+ *   http://localhost:3000/a/b?x=1#y    → true
+ *
+ * Returns false on parse errors so a malformed URL never silently activates
+ * single-page mode.
+ *
+ * @param {string} u
+ * @returns {boolean}
+ */
+export function hasNonRootPath(u) {
+  try {
+    const parsed = new URL(u)
+    const p = parsed.pathname
+    return p !== '' && p !== '/'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Single-page mode is active when the user explicitly passed at least one URL
+ * with a non-root path. The CLI documents this as "Specific page" capture
+ * (see apps/docs/src/app/cli/page.tsx) and the implementation must match —
+ * skip link-following from the page, skip filesystem route discovery, skip
+ * config.routes/skeletons augmentation. The given URLs ARE the queue.
+ *
+ * Bare origins (`http://localhost:3000`) and the empty list (auto-detect)
+ * keep the legacy crawl-everything behaviour.
+ *
+ * @param {string[]} urls
+ * @returns {boolean}
+ */
+export function isSinglePageMode(urls) {
+  if (!Array.isArray(urls) || urls.length === 0) return false
+  return urls.some(hasNonRootPath)
+}

--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boneyard-js",
-  "version": "1.7.9",
+  "version": "1.8.0",
   "description": "Pixel-perfect skeleton loading screens. Wrap your component in <Skeleton> and boneyard snapshots the real DOM layout — no manual descriptors, no configuration.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/boneyard/src/cli-url.test.ts
+++ b/packages/boneyard/src/cli-url.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'bun:test'
+// @ts-expect-error — JS module without .d.ts; the helpers are pure
+import { hasNonRootPath, isSinglePageMode } from '../bin/url-helpers.js'
+
+// ── hasNonRootPath ─────────────────────────────────────────────────────────
+
+describe('hasNonRootPath', () => {
+  it('returns false for a bare origin', () => {
+    expect(hasNonRootPath('http://localhost:3000')).toBe(false)
+  })
+
+  it('returns false for the root path', () => {
+    expect(hasNonRootPath('http://localhost:3000/')).toBe(false)
+  })
+
+  it('returns true for a single-segment path', () => {
+    expect(hasNonRootPath('http://localhost:3000/dashboard')).toBe(true)
+  })
+
+  it('returns true for a multi-segment path', () => {
+    expect(hasNonRootPath('http://localhost:3000/dashboard/analytics')).toBe(true)
+  })
+
+  it('ignores query strings and fragments — only the path matters', () => {
+    expect(hasNonRootPath('http://localhost:3000/?tab=1')).toBe(false)
+    expect(hasNonRootPath('http://localhost:3000/foo?tab=1#section')).toBe(true)
+  })
+
+  it('handles https and non-default ports', () => {
+    expect(hasNonRootPath('https://example.com')).toBe(false)
+    expect(hasNonRootPath('https://example.com/app')).toBe(true)
+    expect(hasNonRootPath('http://localhost:5173/admin/users')).toBe(true)
+  })
+
+  it('returns false for malformed URLs (never accidentally activate single-page mode)', () => {
+    expect(hasNonRootPath('not-a-url')).toBe(false)
+    expect(hasNonRootPath('')).toBe(false)
+    // @ts-expect-error — testing runtime defensiveness
+    expect(hasNonRootPath(null)).toBe(false)
+  })
+})
+
+// ── isSinglePageMode ──────────────────────────────────────────────────────
+
+describe('isSinglePageMode', () => {
+  it('returns false for the empty list (no URL → auto-detect → crawl)', () => {
+    expect(isSinglePageMode([])).toBe(false)
+  })
+
+  it('returns false for a single bare origin (the default crawl entry)', () => {
+    expect(isSinglePageMode(['http://localhost:3000'])).toBe(false)
+  })
+
+  it('returns true for a single URL with a path', () => {
+    expect(isSinglePageMode(['http://localhost:3000/dashboard/analytics'])).toBe(true)
+  })
+
+  it('returns true if any URL in the list has a non-root path', () => {
+    expect(isSinglePageMode([
+      'http://localhost:3000',
+      'http://localhost:3000/dashboard',
+    ])).toBe(true)
+  })
+
+  it('returns false if every URL is a bare origin', () => {
+    expect(isSinglePageMode([
+      'http://localhost:3000',
+      'http://localhost:4000',
+    ])).toBe(false)
+  })
+
+  it('handles non-array inputs defensively', () => {
+    // @ts-expect-error — testing runtime defensiveness
+    expect(isSinglePageMode(null)).toBe(false)
+    // @ts-expect-error — testing runtime defensiveness
+    expect(isSinglePageMode(undefined)).toBe(false)
+  })
+})

--- a/packages/boneyard/src/vite.ts
+++ b/packages/boneyard/src/vite.ts
@@ -17,7 +17,6 @@
 
 import { resolve, join } from 'path'
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs'
-import { createHash } from 'crypto'
 import type { Plugin, ViteDevServer } from 'vite'
 import { detectRegistryExtension } from '../bin/registry-file.js'
 
@@ -32,19 +31,67 @@ export interface BoneyardPluginOptions {
   framework?: 'react' | 'vue' | 'svelte' | 'preact'
   /** Skip initial capture on server start (default: false) */
   skipInitial?: boolean
-  /** Connect to existing Chrome via debug port instead of launching Playwright */
+  /** Connect to existing Chrome via debug port instead of launching Playwright (reuses cookies, auth, state) */
   cdp?: number
   /** Routes to capture skeletons from (default: ['/']). The plugin visits each route at every breakpoint. */
   routes?: string[]
+  /** Verbose per-step logging — useful when capture returns nothing and you need to see why */
+  debug?: boolean
+}
+
+type BoneyardConfig = {
+  routes?: string[]
+  breakpoints?: number[]
+  wait?: number
+  out?: string
+  auth?: {
+    cookies?: Array<{ name: string; value: string; domain?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: 'Strict' | 'Lax' | 'None' }>
+    headers?: Record<string, string>
+  }
+}
+
+const ALLOWED_COOKIE_KEYS = new Set(['name', 'value', 'path', 'domain', 'expires', 'httpOnly', 'secure', 'sameSite'])
+const BLOCKED_HEADERS = new Set(['host', 'content-length', 'transfer-encoding', 'connection', 'upgrade'])
+
+function loadConfig(root: string): BoneyardConfig | null {
+  const p = resolve(root, 'boneyard.config.json')
+  if (!existsSync(p)) return null
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8')) as BoneyardConfig
+  } catch (e: any) {
+    console.log(`  \x1b[35m[boneyard]\x1b[0m failed to parse boneyard.config.json — ${e.message}`)
+    return null
+  }
+}
+
+function sanitizeCookies(cookies: NonNullable<BoneyardConfig['auth']>['cookies']): any[] {
+  if (!cookies) return []
+  return cookies.map(c => {
+    const safe: Record<string, any> = {}
+    for (const [k, v] of Object.entries(c)) {
+      if (ALLOWED_COOKIE_KEYS.has(k)) safe[k] = v
+    }
+    return safe
+  })
+}
+
+function sanitizeHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+  if (!headers) return {}
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) {
+    if (BLOCKED_HEADERS.has(k.toLowerCase())) {
+      console.log(`  \x1b[35m[boneyard]\x1b[0m blocked unsafe header '${k}' in auth config`)
+      continue
+    }
+    out[k] = v
+  }
+  return out
 }
 
 export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
-  const {
-    breakpoints = [375, 768, 1280],
-    wait = 800,
-    skipInitial = false,
-    routes = ['/'],
-  } = options
+  const debug = options.debug === true
+  const log = (msg: string) => console.log(`  \x1b[35m[boneyard]\x1b[0m ${msg}`)
+  const dbg = (msg: string) => { if (debug) log(msg) }
 
   let outDir = options.out ?? ''
   let detectedFramework = options.framework ?? ''
@@ -55,6 +102,14 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
   let page: any = null
   let initialCaptureDone = false
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let loadedConfig: BoneyardConfig | null = null
+
+  // Options may be overridden by boneyard.config.json — resolved in configureServer.
+  let breakpoints = options.breakpoints ?? [375, 768, 1280]
+  let wait = options.wait ?? 800
+  let routes = options.routes ?? ['/']
+  const skipInitial = options.skipInitial === true
+  const cdpPort = options.cdp
 
   function detectOutDir(root: string): string {
     if (outDir) return resolve(root, outDir)
@@ -77,19 +132,44 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
     return 'react'
   }
 
-  const cdpPort = options.cdp
-
   async function ensureBrowser() {
     if (browser && page) return
     const pw = await import('playwright')
+    let context: any
     if (cdpPort) {
+      dbg(`connecting to Chrome on port ${cdpPort}`)
       browser = await pw.chromium.connectOverCDP(`http://localhost:${cdpPort}`)
-      const context = await browser.newContext()
-      page = await context.newPage()
+      // Reuse the existing browser context so cookies and auth state from
+      // the user's Chrome session carry over (matches the CLI's --cdp fix
+      // in #73). A fresh context would throw away any logged-in session.
+      context = browser.contexts()[0] ?? await browser.newContext()
     } else {
+      dbg('launching headless chromium')
       browser = await pw.chromium.launch()
-      page = await browser.newPage()
+      context = await browser.newContext()
     }
+    page = await context.newPage()
+
+    // Apply auth from boneyard.config.json, if any.
+    const auth = loadedConfig?.auth
+    if (auth?.cookies?.length) {
+      const cookies = sanitizeCookies(auth.cookies)
+      log(`applying ${cookies.length} cookie(s) from boneyard.config.json`)
+      try {
+        await context.addCookies(cookies)
+      } catch (e: any) {
+        log(`failed to apply cookies — ${e.message}`)
+      }
+    }
+    if (auth?.headers && Object.keys(auth.headers).length) {
+      const headers = sanitizeHeaders(auth.headers)
+      const count = Object.keys(headers).length
+      if (count) {
+        log(`applying ${count} header(s) from boneyard.config.json`)
+        await page.setExtraHTTPHeaders(headers)
+      }
+    }
+
     await page.addInitScript(() => {
       (window as any).__BONEYARD_BUILD = true
     })
@@ -106,6 +186,7 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       const fw = detectFramework(root)
       const registryFilename = `registry.${detectRegistryExtension(root)}`
       const collected: Record<string, any> = {}
+      const routeDiagnostics: Array<{ path: string; finalPath: string; redirected: boolean; markerCount: number; title: string; error?: string }> = []
 
       const pageUrls = routes.map(route => {
         const r = route.startsWith('/') ? route : `/${route}`
@@ -113,20 +194,64 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       })
 
       for (const pageUrl of pageUrls) {
+        const requestedPath = new URL(pageUrl).pathname
+        const diag: typeof routeDiagnostics[number] = {
+          path: requestedPath,
+          finalPath: requestedPath,
+          redirected: false,
+          markerCount: 0,
+          title: '',
+        }
+
         for (const width of breakpoints) {
           await page.setViewportSize({ width, height: 900 })
 
           try {
             await page.goto(pageUrl, { waitUntil: 'networkidle', timeout: 15_000 })
-          } catch {
-            // networkidle can timeout — still try
+          } catch (e: any) {
+            // networkidle can legitimately time out on long-polling pages,
+            // but other errors (DNS, connection refused, invalid URL) are
+            // usually fatal for this route. Record either way so the user
+            // has something to look at when nothing is captured.
+            const isTimeout = e?.name === 'TimeoutError' || /timeout/i.test(e?.message ?? '')
+            if (!isTimeout) {
+              diag.error = e?.message ?? String(e)
+            } else {
+              dbg(`${requestedPath} @ ${width}px — networkidle timeout (proceeding anyway)`)
+            }
+          }
+
+          // Detect auth redirects etc. Once is enough — only log on first breakpoint.
+          if (width === breakpoints[0]) {
+            const finalUrl = page.url()
+            try {
+              const finalPath = new URL(finalUrl).pathname
+              diag.finalPath = finalPath
+              diag.redirected = finalPath !== requestedPath
+              if (diag.redirected) {
+                log(`\x1b[33m⚠  Redirected: ${requestedPath} → ${finalPath}\x1b[0m`)
+              }
+            } catch {}
           }
 
           if (wait > 0) await page.waitForTimeout(wait)
 
+          // Capture page-level diagnostics once per route (cheapest breakpoint).
+          if (width === breakpoints[0]) {
+            try {
+              const info = await page.evaluate(() => ({
+                title: document.title ?? '',
+                markerCount: document.querySelectorAll('[data-boneyard]').length,
+              }))
+              diag.title = info.title
+              diag.markerCount = info.markerCount
+              dbg(`${requestedPath} — title="${info.title}", ${info.markerCount} <Skeleton> marker(s)`)
+            } catch {}
+          }
+
           const bones = await page.evaluate(() => {
             const fn = (window as any).__BONEYARD_SNAPSHOT
-            if (!fn) return {}
+            if (!fn) return { __error: 'no-snapshot-fn' as const }
 
             const elements = document.querySelectorAll('[data-boneyard]')
             const results: Record<string, any> = {}
@@ -142,34 +267,70 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
               try {
                 results[name] = fn(target, name, config)
-              } catch {}
+              } catch (err: any) {
+                results[name] = { __error: err?.message ?? String(err) }
+              }
             }
 
             return results
           })
 
-          for (const [name, result] of Object.entries(bones)) {
+          if (bones && typeof bones === 'object' && '__error' in (bones as any)) {
+            // No __BONEYARD_SNAPSHOT on the page — the <Skeleton> component
+            // didn't mount. Most likely the user is capturing a route that
+            // doesn't render a <Skeleton>, or the registry import isn't
+            // being loaded by the app entry.
+            if (width === breakpoints[0]) {
+              log(`\x1b[33m⚠  ${requestedPath} — __BONEYARD_SNAPSHOT not on window; <Skeleton> may not have mounted\x1b[0m`)
+            }
+            continue
+          }
+
+          for (const [name, result] of Object.entries(bones as Record<string, any>)) {
             if (!result) continue
+            if (result.__error) {
+              log(`\x1b[33m⚠  ${requestedPath} — ${name}: snapshot threw: ${result.__error}\x1b[0m`)
+              continue
+            }
             const safeName = name.replace(/[^a-zA-Z0-9_-]/g, '_')
             if (!collected[safeName]) collected[safeName] = { breakpoints: {} }
 
             // Compact bones
-            const r = result as any
-            if (r.bones) {
-              r.bones = r.bones.map((b: any) => {
+            if (result.bones) {
+              result.bones = result.bones.map((b: any) => {
                 const arr = [b.x, b.y, b.w, b.h, b.r]
                 if (b.c) arr.push(true)
                 return arr
               })
             }
-            collected[safeName].breakpoints[width] = r
+            collected[safeName].breakpoints[width] = result
           }
         }
+
+        routeDiagnostics.push(diag)
       }
 
       // Check if anything changed
       const snapshot = JSON.stringify(collected)
-      if (snapshot === lastSnapshot || Object.keys(collected).length === 0) {
+      if (Object.keys(collected).length === 0) {
+        // Nothing captured. Always print the per-route rundown so the user
+        // can see why — this is the failure mode #75 flagged.
+        log('captured 0 skeletons — nothing to write')
+        for (const d of routeDiagnostics) {
+          const bits = [`  ${d.path}`]
+          if (d.redirected) bits.push(`→ ${d.finalPath}`)
+          if (d.error) bits.push(`[error: ${d.error}]`)
+          if (d.title) bits.push(`title="${d.title}"`)
+          bits.push(`${d.markerCount} marker(s)`)
+          log(bits.join(' '))
+        }
+        if (routeDiagnostics.every(d => d.markerCount === 0)) {
+          log('no <Skeleton> markers anywhere — is the registry import wired up? did the pages redirect to a login screen?')
+        }
+        return
+      }
+      if (snapshot === lastSnapshot) {
+        dbg('snapshot unchanged — no files rewritten')
         return
       }
       lastSnapshot = snapshot
@@ -211,12 +372,16 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
       writeFileSync(join(outputDir, registryFilename), registryLines.join('\n'))
 
       const ts = new Date().toLocaleTimeString()
-      console.log(`  \x1b[35m[boneyard]\x1b[0m ${ts} — ${names.length} skeleton${names.length !== 1 ? 's' : ''} captured`)
+      log(`${ts} — ${names.length} skeleton${names.length !== 1 ? 's' : ''} captured`)
 
     } catch (err: any) {
-      // Silently handle errors — server might be restarting
-      if (err.message && !err.message.includes('Target closed')) {
-        console.log(`  \x1b[35m[boneyard]\x1b[0m error: ${err.message}`)
+      // "Target closed" happens legitimately when the dev server restarts
+      // or the browser was torn down mid-capture — not worth alerting on.
+      if (err?.message?.includes('Target closed')) {
+        dbg(`capture aborted — ${err.message}`)
+      } else {
+        log(`\x1b[31m✗  capture failed: ${err?.message ?? err}\x1b[0m`)
+        if (debug && err?.stack) console.log(err.stack)
       }
     } finally {
       capturing = false
@@ -229,6 +394,25 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
     configureServer(srv) {
       server = srv
+
+      // Load boneyard.config.json once at startup. Plugin options still win
+      // when both are set, so config is treated as a fallback.
+      loadedConfig = loadConfig(srv.config.root)
+      if (loadedConfig) {
+        dbg('loaded boneyard.config.json')
+        if (options.breakpoints === undefined && Array.isArray(loadedConfig.breakpoints)) {
+          breakpoints = loadedConfig.breakpoints
+        }
+        if (options.wait === undefined && typeof loadedConfig.wait === 'number') {
+          wait = loadedConfig.wait
+        }
+        if (options.out === undefined && typeof loadedConfig.out === 'string') {
+          outDir = loadedConfig.out
+        }
+        if (options.routes === undefined && Array.isArray(loadedConfig.routes) && loadedConfig.routes.length) {
+          routes = loadedConfig.routes
+        }
+      }
 
       // Clean up browser when dev server closes
       srv.httpServer?.on('close', async () => {
@@ -247,7 +431,8 @@ export function boneyardPlugin(options: BoneyardPluginOptions = {}): Plugin {
 
           // Delay initial capture to let the server fully start
           setTimeout(async () => {
-            console.log(`  \x1b[35m[boneyard]\x1b[0m watching for skeleton changes...`)
+            log(`watching for skeleton changes...`)
+            dbg(`routes: ${routes.join(', ')}  breakpoints: ${breakpoints.join(', ')}px`)
             await capture(url, srv.config.root)
             initialCaptureDone = true
           }, 2000)


### PR DESCRIPTION
Minor release rolling up the two open issues.

## Fixes

### Vite plugin no longer fails silently — fixes [#75](https://github.com/0xGF/boneyard/issues/75) (was [#77](https://github.com/0xGF/boneyard/pull/77))

Three places in the Vite plugin used to swallow errors silently — `page.goto` failures, empty captures, and most exceptions in the outer catch — leaving users staring at `[boneyard] watching for skeleton changes...` with no way to diagnose. Now:

- Per-route rundown when capture returns nothing: final path (so redirects are visible), page title, `data-boneyard` marker count, any `page.goto` error, hint about registry wiring vs auth redirect.
- Redirects log at the first breakpoint as they happen (matching the CLI's `⚠  Redirected: /foo → /bar` format).
- Outer catch logs all real failures; only the benign `Target closed` (dev-server restart / browser teardown) stays quiet. Stack traces with `debug: true`.
- `__BONEYARD_SNAPSHOT` missing on a page is now a visible warning instead of silent.
- Per-skeleton snapshot throws propagate as warnings with the skeleton name and error message.

Plus two things that made the auth case worse:

- Vite plugin now reads `boneyard.config.json` — `routes`, `breakpoints`, `wait`, `out` as fallbacks (plugin options still win); `auth.cookies` / `auth.headers` sanitized against the same allowlist/blocklist the CLI uses and applied via `context.addCookies` / `page.setExtraHTTPHeaders`.
- Plugin's `cdp:` reuses the existing Chrome context (`browser.contexts()[0] ?? browser.newContext()`) — same fix as [#73](https://github.com/0xGF/boneyard/pull/73) in the CLI. Inherits cookies/auth from the Chrome window you point it at.

New `debug: true` plugin option for verbose per-step logging.

### `npx boneyard-js build <url>/path` actually captures only that page — fixes [#78](https://github.com/0xGF/boneyard/issues/78)

The CLI documents `npx boneyard-js build http://localhost:3000/dashboard` as the way to capture a "Specific page" ([apps/docs/src/app/cli/page.tsx#L121](https://github.com/0xGF/boneyard/blob/release/v1.8.0/apps/docs/src/app/cli/page.tsx#L121)). The implementation ignored that contract: every URL was treated as a starting point, then expanded by unconditionally:

1. Following same-origin `<a>` links from the page
2. Walking `app/**/page.tsx` etc. for additional Next.js routes
3. Adding anything in `config.routes`

So passing `/dashboard/analytics` still scanned the whole project. Now: when any URL has a non-root path, the CLI prints `Specific page: 1 URL(s) — no link/filesystem crawl` and visits exactly the URL(s) you passed. Bare-origin URLs (`http://localhost:3000`) and the auto-detect path keep the legacy crawl-everything behaviour. Watch-mode recapture also stops following links out of the explicit URLs.

Logic lives in `bin/url-helpers.js` (pure, no deps) so it's unit-tested from `src/cli-url.test.ts` — 13 cases covering bare origins, root paths, multi-segment paths, query strings, https, malformed URLs, and the any-URL-has-a-path multi-URL case.

## Cross-codebase audit

- **Vite plugin** is already explicit-routes-only by design (no link-following, no filesystem walk) — `routes: ['/dashboard']` already captures just that page. Semantics now match the CLI.
- **React Native CLI** uses `runScan`, doesn't web-crawl — no change.
- **Watch mode** in the CLI is gated by the same `singlePageMode` flag.
- **`config.routes` / `config.skeletons`** are skipped when an explicit URL has a path — explicit URL trumps config.

## Test plan

- [x] `pnpm --filter boneyard-js run build` — clean.
- [x] `pnpm --filter boneyard-js run test` — 136 pass / 0 fail (was 123 — added 13 new).
- [x] CLI smoke test against an unreachable origin: path URL prints `Specific page: 1 URL(s) — no link/filesystem crawl` and visits only the explicit URL; bare origin still prints `Crawling http://...` and follows the legacy path.
- [x] Multi-URL smoke test: `build http://x/foo http://x/bar` → `Specific pages: 2 URL(s)`, both visited, no crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)