### PR TITLE
fix(docs): correct skeleton import path in examples

### DIFF
--- a/apps/docs/src/components/skeleton-demo.tsx
+++ b/apps/docs/src/components/skeleton-demo.tsx
@@ -736,7 +736,7 @@ function DemoCard({ demoKey, label, description, Component }: { demoKey: string;
           <div className="relative rounded-xl border border-stone-200 bg-[#1a1a1a] p-4 mt-2 max-h-[400px] overflow-auto">
             <CopyButton text={codeStr} />
             <pre className="text-[11px] font-mono leading-relaxed whitespace-pre">
-              <span className="text-[#c084fc]">import</span><span className="text-stone-300"> {"{ Skeleton }"} </span><span className="text-[#c084fc]">from</span><span className="text-[#86efac]"> &apos;boneyard/react&apos;apos;boneyard-js/react&apos;boneyard/react&apos;apos;</span>{"\n\n"}
+              <span className="text-[#c084fc]">import</span><span className="text-stone-300"> {"{ Skeleton }"} </span><span className="text-[#c084fc]">from</span><span className="text-[#86efac]"> &apos;boneyard-js/react&apos;</span>{"\n\n"}
               <span className="text-[#c084fc]">function</span><span className="text-[#fde68a]"> {compName}Page</span><span className="text-stone-300">() {"{"}</span>{"\n"}
               <span className="text-stone-300">  </span><span className="text-[#c084fc]">const</span><span className="text-stone-300"> {"{ data, isLoading }"} = </span><span className="text-[#fde68a]">useFetch</span><span className="text-stone-300">(</span><span className="text-[#86efac]">&apos;/api/{demoKey}&apos;</span><span className="text-stone-300">)</span>{"\n\n"}
               <span className="text-stone-300">  </span><span className="text-[#c084fc]">return</span><span className="text-stone-300"> (</span>{"\n"}


### PR DESCRIPTION
# Summary

This PR fixes an invalid import shown in the docs examples.

The current import mistake can be seen on [https://boneyard.vercel.app/try-it](https://boneyard.vercel.app/try-it), where the generated snippet shows the wrong package path instead of `boneyard-js/react`.

# Changes

- Fixed the import path in the docs skeleton demo example