### PR TITLE
feat(react): add <BoneSuspense> for React Suspense + useSuspenseQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ function BlogPage() {
 }
 ```
 
+#### With `<Suspense>` / `useSuspenseQuery`
+
+Drop in `<BoneSuspense>` anywhere you'd use a `<Suspense>` boundary. The skeleton renders as the fallback at runtime, and the CLI captures bones from the resolved children at build time.
+
+```tsx
+import { BoneSuspense } from 'boneyard-js/react'
+
+function Page() {
+  return (
+    <BoneSuspense name="user-card">
+      <UserCard />  {/* uses useSuspenseQuery */}
+    </BoneSuspense>
+  )
+}
+```
+
+No `initialData` or `placeholderData` required — the build-time `--wait` window lets the query resolve naturally. Pass a `fixture` if the query can't finish in time.
+
 ### Vue
 
 ```vue

--- a/packages/boneyard/dist/react.js
+++ b/packages/boneyard/dist/react.js
@@ -1,5 +1,5 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { useRef, useState, useEffect, useLayoutEffect } from 'react';
+import { Suspense, useRef, useState, useEffect, useLayoutEffect } from 'react';
 import { normalizeBone } from './types.js';
 import { adjustColor, ensureBuildSnapshotHook, getRegisteredBones, isBuildMode, registerBones, resolveResponsive, SHIMMER, PULSE, DEFAULTS, } from './shared.js';
 ensureBuildSnapshotHook();
@@ -175,4 +175,36 @@ export function Skeleton({ loading, children, name, initialBones, color, darkCol
                             }
                             return _jsx("div", { "data-boneyard-bone": "true", className: resolvedBoneClass, style: boneStyle }, i);
                         }), animationStyle === 'pulse' && (_jsx("style", { children: `@keyframes bp-${uid}{0%,100%{background-color:${resolvedColor}}50%{background-color:${adjustColor(resolvedColor, isDark ? PULSE.darkAdjust : PULSE.lightAdjust)}}}` })), animationStyle === 'shimmer' && (_jsx("style", { children: `@keyframes bs-${uid}{0%{background-position:200% 0}100%{background-position:-200% 0}}` })), staggerMs > 0 && (_jsx("style", { children: `@keyframes by-${uid}{from{opacity:0}to{opacity:1}}` }))] }) }))] }));
+}
+/**
+ * Suspense-aware skeleton wrapper. Use with React's `<Suspense>` model —
+ * components that throw promises (e.g., `useSuspenseQuery`) suspend, and a
+ * `<Skeleton>` is shown as the fallback.
+ *
+ * ```tsx
+ * <BoneSuspense name="user-card">
+ *   <UserCard />  // uses useSuspenseQuery
+ * </BoneSuspense>
+ * ```
+ *
+ * At runtime, behaves like `<Suspense fallback={<Skeleton name="..." loading />}>`.
+ *
+ * At build time (`npx boneyard-js build`), wraps children in `<Suspense>` so a
+ * suspending query doesn't crash extraction. The CLI's `--wait` window lets the
+ * query resolve naturally; the resolved DOM is then snapshotted. Pass `fixture`
+ * for a build-time fallback if the query can't resolve in the wait window.
+ */
+export function BoneSuspense({ children, name, initialBones, color, darkColor, animate, stagger, transition, boneClass, className, fallback, fixture, snapshotConfig, }) {
+    if (isBuildMode()) {
+        const dataAttrs = {};
+        if (name) {
+            dataAttrs['data-boneyard'] = name;
+            if (snapshotConfig) {
+                dataAttrs['data-boneyard-config'] = JSON.stringify(snapshotConfig);
+            }
+        }
+        return (_jsx("div", { className: className, style: { position: 'relative' }, ...dataAttrs, children: _jsx("div", { children: _jsx(Suspense, { fallback: fixture ?? null, children: children }) }) }));
+    }
+    const skeletonFallback = (_jsx(Skeleton, { loading: true, name: name, initialBones: initialBones, color: color, darkColor: darkColor, animate: animate, stagger: stagger, transition: transition, boneClass: boneClass, className: className, fallback: fallback, fixture: fixture, snapshotConfig: snapshotConfig, children: null }));
+    return _jsx(Suspense, { fallback: skeletonFallback, children: children });
 }

--- a/packages/boneyard/src/react.test.tsx
+++ b/packages/boneyard/src/react.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { renderToString } from 'react-dom/server'
+import { Skeleton, BoneSuspense } from './react.js'
+import { registerBones } from './shared.js'
+import type { SkeletonResult } from './types.js'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function setBuildMode(on: boolean) {
+  const w = ((globalThis as any).window ??= {})
+  if (on) w.__BONEYARD_BUILD = true
+  else delete w.__BONEYARD_BUILD
+}
+
+function SuspendingChild(): never {
+  throw new Promise<void>(() => {})
+}
+
+function ResolvedCard() {
+  return <div className="resolved-card">Real Data</div>
+}
+
+const userCardBones: SkeletonResult = {
+  name: 'user-card',
+  viewportWidth: 375,
+  width: 375,
+  height: 80,
+  bones: [
+    { x: 0, y: 0, w: 100, h: 20, r: 4 },
+    { x: 0, y: 30, w: 60, h: 14, r: 4 },
+  ],
+}
+
+// ── Skeleton smoke tests in build mode ─────────────────────────────────────
+
+describe('Skeleton (build mode)', () => {
+  beforeEach(() => setBuildMode(true))
+  afterEach(() => setBuildMode(false))
+
+  it('emits data-boneyard wrapper around children for CLI capture', () => {
+    const html = renderToString(
+      <Skeleton name="card" loading={true}>
+        <div className="real-content">Hello</div>
+      </Skeleton>,
+    )
+    expect(html).toContain('data-boneyard="card"')
+    expect(html).toContain('real-content')
+  })
+
+  it('prefers fixture over children when both are provided', () => {
+    const html = renderToString(
+      <Skeleton
+        name="card"
+        loading={true}
+        fixture={<div className="my-fixture">Fixture</div>}
+      >
+        <div className="real-content">Hello</div>
+      </Skeleton>,
+    )
+    expect(html).toContain('my-fixture')
+    expect(html).not.toContain('real-content')
+  })
+})
+
+// ── BoneSuspense ───────────────────────────────────────────────────────────
+
+describe('BoneSuspense (runtime)', () => {
+  beforeEach(() => setBuildMode(false))
+
+  it('renders children when they do not suspend', () => {
+    const html = renderToString(
+      <BoneSuspense name="user-card">
+        <ResolvedCard />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('resolved-card')
+    expect(html).toContain('Real Data')
+  })
+
+  it('shows the Skeleton fallback when children suspend', () => {
+    registerBones({ 'user-card': userCardBones })
+    const html = renderToString(
+      <BoneSuspense name="user-card" initialBones={userCardBones}>
+        <SuspendingChild />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('data-boneyard-content')
+    expect(html).not.toContain('resolved-card')
+  })
+
+  it('Skeleton fallback receives the configured name and class', () => {
+    const html = renderToString(
+      <BoneSuspense
+        name="user-card"
+        initialBones={userCardBones}
+        className="suspense-wrap"
+      >
+        <SuspendingChild />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('suspense-wrap')
+    expect(html).toContain('data-boneyard-content')
+  })
+
+  it('passes the user-provided fallback through to Skeleton', () => {
+    const html = renderToString(
+      <BoneSuspense
+        name="missing-skeleton"
+        fallback={<div className="custom-fallback">Loading…</div>}
+      >
+        <SuspendingChild />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('custom-fallback')
+    expect(html).toContain('Loading')
+  })
+})
+
+describe('BoneSuspense (build mode)', () => {
+  beforeEach(() => setBuildMode(true))
+  afterEach(() => setBuildMode(false))
+
+  it('wraps children in a data-boneyard region the CLI can find', () => {
+    const html = renderToString(
+      <BoneSuspense name="user-card">
+        <ResolvedCard />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('data-boneyard="user-card"')
+    expect(html).toContain('resolved-card')
+  })
+
+  it('serializes snapshotConfig to data attribute for CLI consumption', () => {
+    const html = renderToString(
+      <BoneSuspense
+        name="user-card"
+        snapshotConfig={{ excludeSelectors: ['.ad-banner'] }}
+      >
+        <ResolvedCard />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('data-boneyard-config')
+    expect(html).toContain('.ad-banner')
+  })
+
+  it('shows the fixture when a suspending query has not resolved yet', () => {
+    const html = renderToString(
+      <BoneSuspense
+        name="user-card"
+        fixture={<div className="build-fixture">Stub Card</div>}
+      >
+        <SuspendingChild />
+      </BoneSuspense>,
+    )
+    expect(html).toContain('data-boneyard="user-card"')
+    expect(html).toContain('build-fixture')
+    expect(html).toContain('Stub Card')
+  })
+
+  it('does not wrap children in a Skeleton overlay during build', () => {
+    const html = renderToString(
+      <BoneSuspense name="user-card" initialBones={userCardBones}>
+        <ResolvedCard />
+      </BoneSuspense>,
+    )
+    expect(html).not.toContain('data-boneyard-overlay')
+    expect(html).not.toContain('data-boneyard-bone')
+  })
+})

--- a/packages/boneyard/src/react.tsx
+++ b/packages/boneyard/src/react.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useLayoutEffect, type ReactNode } from 'react'
+import { Suspense, useRef, useState, useEffect, useLayoutEffect, type ReactNode } from 'react'
 import { normalizeBone } from './types.js'
 import type { Bone, AnyBone, SkeletonResult, ResponsiveBones, SnapshotConfig, AnimationStyle } from './types.js'
 import {
@@ -303,4 +303,82 @@ export function Skeleton({
       )}
     </div>
   )
+}
+
+export interface BoneSuspenseProps extends Omit<SkeletonProps, 'loading'> {
+  /** Component(s) that suspend — typically using `useSuspenseQuery` or `React.lazy`. */
+  children: ReactNode
+}
+
+/**
+ * Suspense-aware skeleton wrapper. Use with React's `<Suspense>` model —
+ * components that throw promises (e.g., `useSuspenseQuery`) suspend, and a
+ * `<Skeleton>` is shown as the fallback.
+ *
+ * ```tsx
+ * <BoneSuspense name="user-card">
+ *   <UserCard />  // uses useSuspenseQuery
+ * </BoneSuspense>
+ * ```
+ *
+ * At runtime, behaves like `<Suspense fallback={<Skeleton name="..." loading />}>`.
+ *
+ * At build time (`npx boneyard-js build`), wraps children in `<Suspense>` so a
+ * suspending query doesn't crash extraction. The CLI's `--wait` window lets the
+ * query resolve naturally; the resolved DOM is then snapshotted. Pass `fixture`
+ * for a build-time fallback if the query can't resolve in the wait window.
+ */
+export function BoneSuspense({
+  children,
+  name,
+  initialBones,
+  color,
+  darkColor,
+  animate,
+  stagger,
+  transition,
+  boneClass,
+  className,
+  fallback,
+  fixture,
+  snapshotConfig,
+}: BoneSuspenseProps) {
+  if (isBuildMode()) {
+    const dataAttrs: Record<string, string> = {}
+    if (name) {
+      dataAttrs['data-boneyard'] = name
+      if (snapshotConfig) {
+        dataAttrs['data-boneyard-config'] = JSON.stringify(snapshotConfig)
+      }
+    }
+    return (
+      <div className={className} style={{ position: 'relative' }} {...dataAttrs}>
+        <div>
+          <Suspense fallback={fixture ?? null}>{children}</Suspense>
+        </div>
+      </div>
+    )
+  }
+
+  const skeletonFallback = (
+    <Skeleton
+      loading={true}
+      name={name}
+      initialBones={initialBones}
+      color={color}
+      darkColor={darkColor}
+      animate={animate}
+      stagger={stagger}
+      transition={transition}
+      boneClass={boneClass}
+      className={className}
+      fallback={fallback}
+      fixture={fixture}
+      snapshotConfig={snapshotConfig}
+    >
+      {null}
+    </Skeleton>
+  )
+
+  return <Suspense fallback={skeletonFallback}>{children}</Suspense>
 }

--- a/packages/boneyard/tsconfig.json
+++ b/packages/boneyard/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
-  "exclude": ["src/**/*.test.ts", "src/test-*.ts", "src/native.tsx", "src/react-native.tsx", "src/preact.tsx", "src/angular.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-*.ts", "src/native.tsx", "src/react-native.tsx", "src/preact.tsx", "src/angular.ts"]
 }


### PR DESCRIPTION
## Summary

Adds `<BoneSuspense>` — a Suspense-aware wrapper that lets boneyard work with React's `<Suspense>` model and TanStack Query's `useSuspenseQuery` without forcing the user to hand-author fixture markup or change how their queries run in production.

Resolves #82.

## Usage

```tsx
import { BoneSuspense } from 'boneyard-js/react'

function Page() {
  return (
    <BoneSuspense name="user-card">
      <UserCard />  {/* uses useSuspenseQuery */}
    </BoneSuspense>
  )
}
```

That's it. No `initialData`, no `placeholderData`, no fixture JSX required for the common case.

## How it works

- **Runtime:** renders as `<Suspense fallback={<Skeleton name="…" loading />}>{children}</Suspense>`. The suspended query throws, Skeleton renders bones from the registry, and real content swaps in when the query resolves.
- **Build (`npx boneyard-js build`):** renders a `data-boneyard` wrapper with a `<Suspense>` boundary inside. The CLI's `--wait` window lets the query resolve naturally — the resolved DOM is then snapshotted. If the query is genuinely slow at build time, an optional `fixture` prop serves as the build-time Suspense fallback (same escape hatch the existing `<Skeleton>` already has).

This matches the API suggested in the issue:
- Accepts the full `<Skeleton>` prop surface (`name`, `initialBones`, `color`, `darkColor`, `animate`, `stagger`, `transition`, `boneClass`, `className`, `fallback`, `fixture`, `snapshotConfig`) minus `loading`, which Suspense owns.
- Does not require `initialData` / `placeholderData` — production query behavior stays untouched.
- Behaves like `<Skeleton>`; the CLI's existing wait knob gives the query time to resolve.

## Changes

- `packages/boneyard/src/react.tsx` — new `BoneSuspense` component + `BoneSuspenseProps` interface.
- `packages/boneyard/src/react.test.tsx` — 10 new tests covering runtime fallback, build-mode capture wrapper, fixture-as-Suspense-fallback, snapshotConfig serialization, and the no-overlay invariant during build.
- `packages/boneyard/tsconfig.json` — extend exclude pattern to also skip `*.test.tsx` from the build (existing pattern only covered `*.test.ts`).
- `README.md` — short subsection under the React quickstart documenting the new component.
- `packages/boneyard/dist/react.js` — regenerated since this file is tracked in the repo.

## Test plan

- [x] `bun test` from `packages/boneyard` — 163 pass / 0 fail (was 153 before; +10 new tests).
- [x] `pnpm --filter boneyard-js run build` — clean tsc + d.ts output, `BoneSuspense` exported from `dist/react.d.ts`.
- [ ] Smoke in a real app with `useSuspenseQuery`: confirm bones render as Suspense fallback at runtime, and that `npx boneyard-js build` captures the resolved DOM (left for maintainer / reporter to verify in the field, since the repro requires a real TanStack Query setup).