### PR TITLE
release: v1.8.2 — <BoneSuspense> for React Suspense + useSuspenseQuery

### DIFF
--- a/apps/docs/src/app/changelog/page.tsx
+++ b/apps/docs/src/app/changelog/page.tsx
@@ -8,12 +8,29 @@ export default function ChangelogPage() {
         </p>
       </div>
 
+      {/* v1.8.2 */}
+      <section>
+        <div className="flex items-center gap-3 mb-4">
+          <span className="text-[14px] font-bold">v1.8.2</span>
+          <span className="text-[12px] text-stone-400">June 2026</span>
+          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-[14px] font-semibold mb-1"><code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">&lt;BoneSuspense&gt;</code> — Suspense-aware skeletons</h3>
+            <p className="text-[13px] text-[#78716c] leading-relaxed">
+              New <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">&lt;BoneSuspense&gt;</code> wrapper for React&apos;s <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">&lt;Suspense&gt;</code> model. Components that suspend — e.g. TanStack Query&apos;s <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">useSuspenseQuery</code> or <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">React.lazy</code> — render a <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">&lt;Skeleton&gt;</code> as the fallback, with no <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">initialData</code> / <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">placeholderData</code> or hand-authored fixture markup required. At build time the CLI&apos;s <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">--wait</code> window lets the query resolve so the real DOM is snapshotted; pass a <code className="text-[12px] bg-stone-100 px-1 py-0.5 rounded">fixture</code> as the build-time fallback if it can&apos;t finish in time. Resolves <a href="https://github.com/0xGF/boneyard/issues/82" className="underline">#82</a> via <a href="https://github.com/0xGF/boneyard/pull/88" className="underline">#88</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* v1.8.1 */}
       <section>
         <div className="flex items-center gap-3 mb-4">
           <span className="text-[14px] font-bold">v1.8.1</span>
           <span className="text-[12px] text-stone-400">April 2026</span>
-          <span className="text-[10px] font-medium text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">latest</span>
         </div>
 
         <div className="space-y-6">

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -34,8 +34,8 @@ export default function RootLayout({
         <BoneRegistryInit />
         {/* Version banner */}
         <a href="/changelog" className="hidden md:flex items-center justify-center gap-1.5 w-full bg-stone-900 py-2 px-4 text-[12px] text-stone-300 hover:text-white transition-colors fixed top-0 left-0 right-0 z-50">
-          <span className="font-medium text-emerald-400">v1.8.1</span>
-          HTTPS dev-server support, previously-captured bones preserved across runs
+          <span className="font-medium text-emerald-400">v1.8.2</span>
+          BoneSuspense — Suspense-aware skeletons for useSuspenseQuery
           <span className="text-stone-500">&rarr;</span>
         </a>
         {/* Centered container for sidebar + content */}

--- a/apps/docs/src/app/overview/page.tsx
+++ b/apps/docs/src/app/overview/page.tsx
@@ -51,7 +51,7 @@ function DashboardMock() {
         </div>
       </article>
       <div className="flex flex-col gap-1">
-        {["v1.8.1 — 7 bones captured", "v1.8.0 — 12 routes scanned"].map((row, i) => (
+        {["v1.8.2 — BoneSuspense added", "v1.8.1 — 7 bones captured"].map((row, i) => (
           <article key={i} className="h-5 bg-stone-50 border border-stone-100 rounded flex items-center px-2 text-[9px] text-stone-500 truncate">{row}</article>
         ))}
       </div>

--- a/apps/docs/src/components/sidebar.tsx
+++ b/apps/docs/src/components/sidebar.tsx
@@ -107,7 +107,7 @@ export function Sidebar() {
       {/* Footer */}
       <div className="py-4 space-y-1.5">
         <div className="flex items-center gap-2">
-          <span className="text-[12px] text-[#a8a29e]">v1.8.1</span>
+          <span className="text-[12px] text-[#a8a29e]">v1.8.2</span>
           <a
             href="https://github.com/0xGF/boneyard"
             target="_blank"

--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boneyard-js",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Pixel-perfect skeleton loading screens. Wrap your component in <Skeleton> and boneyard snapshots the real DOM layout — no manual descriptors, no configuration.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.8.2

Patch release shipping the `<BoneSuspense>` component merged in #88.

### Included
- **feat(react):** `<BoneSuspense>` — Suspense-aware skeleton wrapper. Components that suspend (TanStack Query's `useSuspenseQuery`, `React.lazy`) render a `<Skeleton>` fallback at runtime; the CLI captures bones from the resolved DOM at build time. No `initialData` / `placeholderData` or hand-authored fixture required. Resolves #82 via #88.

### Version bump
- `packages/boneyard/package.json`: `1.8.1` → `1.8.2`
- docs: version banner, sidebar, overview, and a new changelog entry bumped to v1.8.2

### Verification
- `bun test` — 153 pass / 0 fail
- `tsc` (package) compiles clean; committed `dist/` matches a fresh build; `BoneSuspense` exported in `dist/react.d.ts`
- `tsc --noEmit` (docs) clean
- Security review of #88 — no findings

> `npm publish` is the manual follow-up after merge (run from `packages/boneyard/`).