### PR TITLE
feat: add aria-busy to skeletons while loading

### DIFF
--- a/packages/boneyard/src/Skeleton.svelte
+++ b/packages/boneyard/src/Skeleton.svelte
@@ -207,6 +207,7 @@
   <div
     class={resolvedClassName}
     style="position:relative;"
+    aria-busy={loading || undefined}
     data-boneyard={name}
     data-boneyard-config={serializedSnapshotConfig}
     {@attach resizeAttachment}

--- a/packages/boneyard/src/Skeleton.vue
+++ b/packages/boneyard/src/Skeleton.vue
@@ -249,6 +249,7 @@ onUnmounted(() => {
     ref="containerRef"
     :class="props.class"
     style="position:relative;"
+    :aria-busy="loading || undefined"
     :data-boneyard="name"
     :data-boneyard-config="serializedSnapshotConfig"
   >

--- a/packages/boneyard/src/angular.ts
+++ b/packages/boneyard/src/angular.ts
@@ -56,6 +56,7 @@ ensureBuildSnapshotHook()
       #container
       [class]="cssClass"
       style="position:relative;"
+      [attr.aria-busy]="loading ? true : null"
       [attr.data-boneyard]="name"
       [attr.data-boneyard-config]="serializedSnapshotConfig"
     >

--- a/packages/boneyard/src/native.tsx
+++ b/packages/boneyard/src/native.tsx
@@ -529,7 +529,7 @@ export function Skeleton({
   const scaleY = (effectiveHeight > 0 && capturedHeight > 0) ? effectiveHeight / capturedHeight : 1
 
   return (
-    <View ref={containerRef} style={[styles.container, style]} onLayout={onLayout} collapsable={false}>
+    <View ref={containerRef} style={[styles.container, style]} onLayout={onLayout} collapsable={false} aria-busy={loading || undefined}>
       {/* Always render children so the container reflects real content height (handles Dynamic Type) */}
       <View style={showSkeleton && !transitioning ? styles.hidden : undefined} pointerEvents={showSkeleton ? 'none' : 'auto'}>
         {showFallback ? fallback ?? null : children}

--- a/packages/boneyard/src/preact.tsx
+++ b/packages/boneyard/src/preact.tsx
@@ -231,7 +231,7 @@ export function Skeleton({
   const scaleY = (effectiveHeight > 0 && capturedHeight > 0) ? effectiveHeight / capturedHeight : 1
 
   return (
-    <div ref={containerRef} className={className} style={{ position: 'relative' }} {...dataAttrs}>
+    <div ref={containerRef} className={className} style={{ position: 'relative' }} aria-busy={loading || undefined} {...dataAttrs}>
       <div data-boneyard-content="true" style={showSkeleton && !transitioning ? { visibility: 'hidden' } : undefined}>
         {showFallback ? fallback : children}
       </div>

--- a/packages/boneyard/src/react.test.tsx
+++ b/packages/boneyard/src/react.test.tsx
@@ -62,6 +62,30 @@ describe('Skeleton (build mode)', () => {
   })
 })
 
+// ── Runtime accessibility ──────────────────────────────────────────────────
+
+describe('Skeleton (runtime a11y)', () => {
+  beforeEach(() => setBuildMode(false))
+
+  it('sets aria-busy on the container while loading', () => {
+    const html = renderToString(
+      <Skeleton name="user-card" loading={true} initialBones={userCardBones}>
+        <div className="real-content">Hello</div>
+      </Skeleton>,
+    )
+    expect(html).toContain('aria-busy="true"')
+  })
+
+  it('omits aria-busy when not loading', () => {
+    const html = renderToString(
+      <Skeleton name="user-card" loading={false} initialBones={userCardBones}>
+        <div className="real-content">Hello</div>
+      </Skeleton>,
+    )
+    expect(html).not.toContain('aria-busy')
+  })
+})
+
 // ── BoneSuspense ───────────────────────────────────────────────────────────
 
 describe('BoneSuspense (runtime)', () => {

--- a/packages/boneyard/src/react.tsx
+++ b/packages/boneyard/src/react.tsx
@@ -243,7 +243,7 @@ export function Skeleton({
   const scaleY = (effectiveHeight > 0 && capturedHeight > 0) ? effectiveHeight / capturedHeight : 1
 
   return (
-    <div ref={containerRef} className={className} style={{ position: 'relative' }} {...dataAttrs}>
+    <div ref={containerRef} className={className} style={{ position: 'relative' }} aria-busy={loading || undefined} {...dataAttrs}>
       <div data-boneyard-content="true" style={showSkeleton && !transitioning ? { visibility: 'hidden' } : undefined}>
         {showFallback ? fallback : children}
       </div>


### PR DESCRIPTION
## What

Adds `aria-busy="true"` to the skeleton container element while `loading` is true, across every framework adapter (React, Preact, Vue, Svelte, Angular, React Native). The attribute is omitted when not loading.

## Why

Requested in #93 — `aria-busy` exposes the loading state to assistive technology and gives e2e tests a stable, semantic hook to wait on instead of relying on internal markers or timing.

## Testing

- New runtime tests assert the attribute is present when `loading` and absent otherwise
- Full suite: 155 pass / 0 fail
- Angular compiles clean

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)