### PR TITLE
feat: select breakpoint by container or viewport width (#92)

### DIFF
--- a/packages/boneyard/README.md
+++ b/packages/boneyard/README.md
@@ -108,6 +108,7 @@ All color values accept any valid CSS color (hex, rgba, hsl, etc.).
 | `shimmerAngle` | `110` | Shimmer gradient angle in degrees |
 | `stagger` | `false` | Delay between bones in ms (`true` = 80ms) |
 | `transition` | `false` | Fade out when loading ends in ms (`true` = 300ms) |
+| `select` | `container` | Width used to pick the responsive breakpoint: `container` (measured width) or `viewport` (`window.innerWidth`). Use `viewport` for app-shell layouts where the container is narrower than the window |
 
 Per-component props override config. Config overrides package defaults.
 

--- a/packages/boneyard/src/angular.ts
+++ b/packages/boneyard/src/angular.ts
@@ -36,6 +36,8 @@ interface BoneyardConfig {
   stagger?: number | boolean
   transition?: number | boolean
   boneClass?: string
+  /** Which width picks the breakpoint: 'container' (default) or 'viewport'. See #92. */
+  select?: 'container' | 'viewport'
 }
 
 let _globalConfig: BoneyardConfig = {}
@@ -123,6 +125,13 @@ export class SkeletonComponent implements AfterContentInit, AfterViewInit, OnDes
   @Input() boneClass?: string
   @Input() cssClass?: string
   @Input() snapshotConfig?: SnapshotConfig
+  /**
+   * Which width selects the responsive breakpoint: `'container'` (default,
+   * the measured container width) or `'viewport'` (`window.innerWidth`, how
+   * the CLI keys captures). Use `'viewport'` for app-shell layouts where the
+   * container is narrower than the window. See #92.
+   */
+  @Input() select?: 'container' | 'viewport'
 
   @ViewChild('container') containerRef!: ElementRef<HTMLDivElement>
 
@@ -274,7 +283,12 @@ export class SkeletonComponent implements AfterContentInit, AfterViewInit, OnDes
   private updateBones(): void {
     const effectiveBones = this.initialBones ?? (this.name ? getRegisteredBones(this.name) : undefined)
     const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : this.containerWidth
-    const resolveWidth = this.containerWidth > 0 ? this.containerWidth : viewportWidth
+    // 'container' (default) keeps container-query selection; 'viewport' matches
+    // how the CLI keys captures — for app-shell layouts (#92).
+    const select = this.select ?? _globalConfig.select ?? 'container'
+    const resolveWidth = select === 'viewport'
+      ? (viewportWidth > 0 ? viewportWidth : this.containerWidth)
+      : (this.containerWidth > 0 ? this.containerWidth : viewportWidth)
     this.activeBones = effectiveBones && resolveWidth > 0
       ? resolveResponsive(effectiveBones, resolveWidth)
       : null

--- a/packages/boneyard/src/preact.tsx
+++ b/packages/boneyard/src/preact.tsx
@@ -27,6 +27,8 @@ interface BoneyardConfig {
   stagger?: number | boolean
   transition?: number | boolean
   boneClass?: string
+  /** Which width picks the breakpoint: 'container' (default) or 'viewport'. See #92. */
+  select?: 'container' | 'viewport'
 }
 
 let globalConfig: BoneyardConfig = {}
@@ -92,6 +94,13 @@ export interface SkeletonProps {
    * Stored as a data attribute — the CLI reads it during capture.
    */
   snapshotConfig?: SnapshotConfig
+  /**
+   * Which width selects the responsive breakpoint: `'container'` (default) or
+   * `'viewport'` (`window.innerWidth`, how the CLI keys captures). Use
+   * `'viewport'` for app-shell layouts where the container is narrower than
+   * the window. See #92.
+   */
+  select?: 'container' | 'viewport'
 }
 
 /**
@@ -116,6 +125,7 @@ export function Skeleton({
   fallback,
   fixture,
   snapshotConfig,
+  select,
 }: SkeletonProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const uid = useRef(Math.random().toString(36).slice(2, 8)).current
@@ -191,7 +201,12 @@ export function Skeleton({
 
   const effectiveBones = initialBones ?? (name ? getRegisteredBones(name) : undefined)
   const viewportWidth = mounted && typeof window !== 'undefined' ? window.innerWidth : 0
-  const resolveWidth = containerWidth > 0 ? containerWidth : viewportWidth
+  // 'container' (default) keeps container-query selection; 'viewport' matches
+  // how the CLI keys captures — for app-shell layouts (#92).
+  const effectiveSelect = select ?? globalConfig.select ?? 'container'
+  const resolveWidth = effectiveSelect === 'viewport'
+    ? (viewportWidth > 0 ? viewportWidth : containerWidth)
+    : (containerWidth > 0 ? containerWidth : viewportWidth)
   const activeBones = effectiveBones && resolveWidth > 0
     ? resolveResponsive(effectiveBones, resolveWidth)
     : null

--- a/packages/boneyard/src/react.test.tsx
+++ b/packages/boneyard/src/react.test.tsx
@@ -62,6 +62,41 @@ describe('Skeleton (build mode)', () => {
   })
 })
 
+// ── Breakpoint selection width (#92) ────────────────────────────────────────
+
+describe('Skeleton (select width)', () => {
+  beforeEach(() => setBuildMode(false))
+
+  const responsive = {
+    breakpoints: {
+      375: { ...userCardBones, viewportWidth: 375, width: 375 },
+      1280: { ...userCardBones, viewportWidth: 1280, width: 1280 },
+    },
+  }
+
+  // SSR (renderToString) has no window/container measurement, so both modes
+  // fall through to width 0 → no overlay. These assert the prop is accepted
+  // and rendering stays stable; runtime width behavior is covered by
+  // resolveResponsive's own tests.
+  it('accepts select="viewport" without error', () => {
+    const html = renderToString(
+      <Skeleton name="user-card" loading={true} initialBones={responsive} select="viewport">
+        <div className="real-content">Hello</div>
+      </Skeleton>,
+    )
+    expect(html).toContain('data-boneyard="user-card"')
+  })
+
+  it('accepts select="container" (default) without error', () => {
+    const html = renderToString(
+      <Skeleton name="user-card" loading={true} initialBones={responsive} select="container">
+        <div className="real-content">Hello</div>
+      </Skeleton>,
+    )
+    expect(html).toContain('data-boneyard="user-card"')
+  })
+})
+
 // ── BoneSuspense ───────────────────────────────────────────────────────────
 
 describe('BoneSuspense (runtime)', () => {

--- a/packages/boneyard/src/react.tsx
+++ b/packages/boneyard/src/react.tsx
@@ -33,6 +33,16 @@ interface BoneyardConfig {
   speed?: string
   /** Shimmer gradient angle in degrees. Default: 110 */
   shimmerAngle?: number
+  /**
+   * Which width picks the responsive breakpoint at runtime:
+   * - `'container'` (default): the skeleton container's measured width — matches
+   *   the space the skeleton actually occupies (container-query-like).
+   * - `'viewport'`: `window.innerWidth` — matches how the CLI keys captures
+   *   (by viewport width). Use this when the container is narrower than the
+   *   viewport (app-shell layouts) and container-width selection picks a
+   *   breakpoint captured under a different layout. See #92.
+   */
+  select?: 'container' | 'viewport'
 }
 
 let globalConfig: BoneyardConfig = {}
@@ -98,6 +108,13 @@ export interface SkeletonProps {
    * Stored as a data attribute — the CLI reads it during capture.
    */
   snapshotConfig?: SnapshotConfig
+  /**
+   * Which width selects the responsive breakpoint: `'container'` (default,
+   * the skeleton's measured width) or `'viewport'` (`window.innerWidth`, how
+   * the CLI keys captures). Use `'viewport'` for app-shell layouts where the
+   * container is narrower than the window. See #92.
+   */
+  select?: 'container' | 'viewport'
 }
 
 /**
@@ -122,6 +139,7 @@ export function Skeleton({
   fallback,
   fixture,
   snapshotConfig,
+  select,
 }: SkeletonProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const uid = useRef(Math.random().toString(36).slice(2, 8)).current
@@ -203,7 +221,13 @@ export function Skeleton({
 
   const effectiveBones = initialBones ?? (name ? getRegisteredBones(name) : undefined)
   const viewportWidth = mounted && typeof window !== 'undefined' ? window.innerWidth : 0
-  const resolveWidth = containerWidth > 0 ? containerWidth : viewportWidth
+  // Which width selects the breakpoint. 'container' (default) keeps the
+  // container-query behavior; 'viewport' matches how the CLI keys captures,
+  // for app-shell layouts where the container is narrower than the window (#92).
+  const effectiveSelect = select ?? globalConfig.select ?? 'container'
+  const resolveWidth = effectiveSelect === 'viewport'
+    ? (viewportWidth > 0 ? viewportWidth : containerWidth)
+    : (containerWidth > 0 ? containerWidth : viewportWidth)
   const activeBones = effectiveBones && resolveWidth > 0
     ? resolveResponsive(effectiveBones, resolveWidth)
     : null
@@ -342,6 +366,7 @@ export function BoneSuspense({
   fallback,
   fixture,
   snapshotConfig,
+  select,
 }: BoneSuspenseProps) {
   if (isBuildMode()) {
     const dataAttrs: Record<string, string> = {}
@@ -375,6 +400,7 @@ export function BoneSuspense({
       fallback={fallback}
       fixture={fixture}
       snapshotConfig={snapshotConfig}
+      select={select}
     >
       {null}
     </Skeleton>


### PR DESCRIPTION
## Background

Bones are captured **keyed by viewport width** (the CLI sets the viewport to each breakpoint and snapshots). But at runtime, React/Preact/Angular select the breakpoint by the **skeleton container's measured width**. In app-shell layouts where the container is much narrower than the viewport, container-width selection picks a smaller breakpoint than the one that produced the matching real layout — the mismatch reported in #92.

(Notably, Vue and Svelte already select viewport-first, so this also reduces cross-framework inconsistency.)

## Change

Adds an opt-in `select` option — as a prop and via `configureBoneyard`:

```tsx
<Skeleton name="user-card" loading select="viewport">…</Skeleton>
```

- `'container'` **(default)** — unchanged behavior; picks the breakpoint from the container's measured width (container-query-like).
- `'viewport'` — picks from `window.innerWidth`, matching how captures are keyed. Fixes the app-shell mismatch.

Implemented for React (incl. `BoneSuspense`), Preact, and Angular — the three container-first adapters. Default is `'container'`, so **no behavior change** unless opted in.

## Testing

- `tsc --noEmit` clean, Angular `ngc` compiles, full suite **155 pass / 0 fail** (new tests assert the prop renders stably in both modes)

## Follow-up

Vue/Svelte currently hard-code viewport-first selection; a later pass could route them through the same `select` option (defaulting to `'viewport'` there) for a fully uniform API.

Addresses #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)