### PR TITLE
release: v1.9.0

### DIFF
--- a/packages/boneyard/package.json
+++ b/packages/boneyard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boneyard-js",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Pixel-perfect skeleton loading screens. Wrap your component in <Skeleton> and boneyard snapshots the real DOM layout — no manual descriptors, no configuration.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Rolls up the merged issue fixes and features into a release.

## Features
- **aria-busy** on skeleton containers while loading — all adapters (#93)
- **`select: 'container' | 'viewport'`** to choose which width picks the breakpoint (#92)

## Fixes
- **Angular** animations dead under ViewEncapsulation / esbuild builder (#95, #86)
- **Vite** plugin resolves `env[...]` in auth config from `.env` (#84)
- **Native** scan preserves existing bones in the registry (#87)

## Docs
- Playwright browser install + reusing an existing browser (#89, #90)

Version: 1.8.2 → **1.9.0** (minor — backward-compatible features + fixes).
Verified: 157 tests pass, `tsc`/`ngc` clean, full `build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)