### PR TITLE
docs: fix stale build filter in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ node packages/boneyard/bin/cli.js build http://localhost:PORT --out apps/docs/sr
 
 ```bash
 # Build the package
-pnpm --filter boneyard run build
+pnpm --filter boneyard-js run build
 
 # Build docs
 pnpm --filter boneyard-docs run build


### PR DESCRIPTION
`pnpm --filter boneyard run build` matches no project — the package is named `boneyard-js` (as the test command already uses). One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)