### PR TITLE
fix(native-scan): resolve public instance before measuring on New Architecture (Fabric)

### DIFF
--- a/packages/boneyard/src/native-scan.tsx
+++ b/packages/boneyard/src/native-scan.tsx
@@ -244,6 +244,22 @@ function extractBorderRadius(style: Record<string, any>): number | string {
 
 // ── Measurement ──────────────────────────────────────────────────────────────
 
+/**
+ * Resolve the public host-component instance that exposes measure/measureLayout.
+ *
+ * On the New Architecture (Fabric) a host fiber's `stateNode` is the internal
+ * Instance, and the measurement methods live on `canonical.publicInstance`
+ * (see React's `getPublicInstance`). On the old architecture (Paper) the
+ * `stateNode` is already that public instance. Measuring the raw Fabric
+ * `stateNode` throws (no `measureLayout`), which `measureView` swallows — so
+ * every bone comes back null and the scan silently captures nothing.
+ */
+function getPublicInstance(stateNode: any): any {
+  if (!stateNode) return stateNode
+  if (typeof stateNode.measureLayout === 'function') return stateNode
+  return stateNode.canonical?.publicInstance ?? stateNode
+}
+
 function measureView(
   view: any,
   relativeTo: any,
@@ -303,7 +319,8 @@ export function BoneScan({
     const bones: Bone[] = []
 
     for (const sv of scannedViews) {
-      const layout = await measureView(sv.stateNode, container)
+      const view = getPublicInstance(sv.stateNode)
+      const layout = await measureView(view, container)
       if (!layout || layout.w < 1 || layout.h < 1) continue
 
       const bone: Bone = {
@@ -315,6 +332,13 @@ export function BoneScan({
       }
       if (sv.isContainer) bone.c = true
       bones.push(bone)
+    }
+
+    if (scannedViews.length > 0 && bones.length === 0) {
+      console.warn(
+        `[BoneScan] "${name}": walked ${scannedViews.length} host views but measured 0 bones. ` +
+          'The views did not report a layout — check that they are backed by native views.',
+      )
     }
 
     const finalBones = compact


### PR DESCRIPTION
## What

`<BoneScan>` / `<BoneScanResponsive>` (`boneyard-js/native-scan`) capture zero bones on the New Architecture (Fabric). The fiber walk runs fine, but every child measurement fails silently, so the emitted skeleton comes out empty with no error.

## Why

`collectHostViews` stores each host fiber's `stateNode`, and `measureView` then calls `stateNode.measureLayout(...)`.

- On Paper, that `stateNode` is the public host component, which has `measureLayout`.
- On Fabric, `stateNode` is the internal Instance. Its measure methods live on `stateNode.canonical.publicInstance` — that's what React's own `getPublicInstance` returns, and `ReactFabric` builds the node as `stateNode = { node, canonical: { nativeTag, publicInstance, ... } }`.

So `measureLayout` is `undefined` on the raw Fabric Instance, the call throws, `measureView`'s `try/catch` swallows it and resolves `null`, every bone is dropped, and the JSON is empty. Nothing surfaces to tell you why.

New Architecture is the default from Expo SDK 52 / RN 0.76+, so this hits most current setups. The primary `<Skeleton name>` path in `native.tsx` is fine — it measures by numeric tag through `UIManager`, which RN reroutes to Fabric.

## Fix

Resolve the public instance before measuring:

```ts
function getPublicInstance(stateNode: any): any {
  if (!stateNode) return stateNode
  if (typeof stateNode.measureLayout === 'function') return stateNode  // Paper
  return stateNode.canonical?.publicInstance ?? stateNode              // Fabric
}
```

Paper returns the same object (the method check short-circuits), so there's no behavior change there. I also added a dev warning when the walk finds host views but measures none, so this can't fail silently again.

`measure` / `measureLayout` on a native-backed instance are the documented APIs ([Element Nodes](https://reactnative.dev/docs/element-nodes), New Architecture layout measurements), so this stays on public surface.

## Testing

Native capture needs a running dev client plus the `:9999` receiver, so there's no headless unit test (same as the rest of the native code). What I verified:

- Root cause read against RN 0.81.5's `ReactFabric` source (`getPublicInstance` → `canonical.publicInstance`; `findNodeHandle` uses the same path).
- The `measure`/`measureLayout` instance API against the RN docs.
- The edited file typechecks in isolation.

I have not run an on-device capture end to end. A maintainer smoke test on a Fabric app before merge would be worth it — wrap a card in `<BoneScan>`, run `npx boneyard-js build --native`, and confirm bones go from 0 to the full set.

## Diff

One helper + one call-site change + a dev warning, all in `src/native-scan.tsx`. No API change.
