### PR TITLE
fix(react): derive skeleton uid from useId() instead of Math.random()

### DIFF
--- a/packages/boneyard/src/react.tsx
+++ b/packages/boneyard/src/react.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useRef, useState, useEffect, useLayoutEffect, type ReactNode } from 'react'
+import { Suspense, useRef, useState, useEffect, useLayoutEffect, useId, type ReactNode } from 'react'
 import { normalizeBone } from './types.js'
 import type { Bone, AnyBone, SkeletonResult, ResponsiveBones, SnapshotConfig, AnimationStyle } from './types.js'
 import {
@@ -142,7 +142,9 @@ export function Skeleton({
   select,
 }: SkeletonProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const uid = useRef(Math.random().toString(36).slice(2, 8)).current
+  // Sanitized because uid is interpolated into CSS animation and @keyframes
+  // identifiers, and useId() returns colon-wrapped values like ":r0:".
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '')
   const [containerWidth, setContainerWidth] = useState(0)
   const [containerHeight, setContainerHeight] = useState(0)
   const [isDark, setIsDark] = useState(false)


### PR DESCRIPTION
## Problem

`Skeleton` in `packages/boneyard/src/react.tsx` derives its `uid` during render:

```ts
const uid = useRef(Math.random().toString(36).slice(2, 8)).current
```

`Math.random()` is non-deterministic across the server and client render passes. Under Next.js 16 App Router with `cacheComponents` (Partial Prerendering) this bails the static prerender, so **any route that renders a `<Skeleton>` emits an empty static shell** and its entire markup is deferred to request time.

The impact compounds when `<Skeleton>` sits in shared chrome. In our app it's used by the component every route-level `loading.tsx` renders, so effectively no route in the application had a usable prerendered shell.

## Reproduction

Single-variable production build, nothing else changed. A public page whose only hooks are `useState`/`useRouter` plus a `<Skeleton>` wrapper:

| `uid` source | prerendered shell |
|---|---|
| `Math.random()` | *(empty)* |
| fixed string | `Forgot Password? Enter your email address and we'll send you a verification code…` |

Control pages held throughout: pages that additionally call `useSearchParams()` stayed empty for that separate reason, and pages using no `<Skeleton>` were unaffected in both builds.

## Fix

Use `useId()`, which is stable across server and client renders. The result is sanitized because `uid` is interpolated into CSS animation and `@keyframes` identifiers (`bp-${uid}`, `bs-${uid}`, `by-${uid}`) and `useId()` returns colon-wrapped values like `:r0:`.

`useId` requires React ≥18; the package already declares `react: >=18`.

## Notes

- `packages/boneyard/src/preact.tsx:131` has the identical line. I left it alone deliberately: `useId` from `preact/hooks` requires Preact ≥10.11 while the peer range here is `preact: >=10`, and `preact.tsx` is copied to `dist` verbatim rather than compiled, so the change would ship unvalidated. Happy to include it if you'd rather bump the peer range.
- Possibly related to #59, though that report is about the first visible frame rather than the prerendered shell.

## Testing

`bun test` in `packages/boneyard` is unchanged at **146 pass / 11 fail**, identical before and after. The 11 failures are pre-existing and environment-related (`getMeasureContext()` returns `null`, so `ctx.font` throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)